### PR TITLE
[feat] global response 추가

### DIFF
--- a/src/main/java/com/ourmenu/backend/global/exception/CustomException.java
+++ b/src/main/java/com/ourmenu/backend/global/exception/CustomException.java
@@ -1,0 +1,20 @@
+package com.ourmenu.backend.global.exception;
+
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/ourmenu/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/ourmenu/backend/global/exception/ErrorCode.java
@@ -4,17 +4,29 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
 
-    INTERNAL_SERVER(HttpStatus.INTERNAL_SERVER_ERROR,"G500","서버 내부에서 에러가 발생하였습니다");
+    INTERNAL_SERVER(HttpStatus.INTERNAL_SERVER_ERROR, "G500", "서버 내부에서 에러가 발생하였습니다");
 
-    private HttpStatus httpStatus;
+    private final HttpStatus httpStatus;
 
-    private String errorCode;
+    private final String code;
 
-    private String errorMessage;
+    private final String message;
 
-    ErrorCode(HttpStatus httpStatus, String errorCode, String errorMessage) {
+    ErrorCode(HttpStatus httpStatus, String code, String message) {
         this.httpStatus = httpStatus;
-        this.errorCode = errorCode;
-        this.errorMessage = errorMessage;
+        this.code = code;
+        this.message = message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
     }
 }

--- a/src/main/java/com/ourmenu/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/ourmenu/backend/global/exception/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.ourmenu.backend.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+
+    INTERNAL_SERVER(HttpStatus.INTERNAL_SERVER_ERROR,"G500","서버 내부에서 에러가 발생하였습니다");
+
+    private HttpStatus httpStatus;
+
+    private String errorCode;
+
+    private String errorMessage;
+
+    ErrorCode(HttpStatus httpStatus, String errorCode, String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/com/ourmenu/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/ourmenu/backend/global/exception/ErrorCode.java
@@ -1,7 +1,11 @@
 package com.ourmenu.backend.global.exception;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+@AllArgsConstructor
+@Getter
 public enum ErrorCode {
 
     INTERNAL_SERVER(HttpStatus.INTERNAL_SERVER_ERROR, "G500", "서버 내부에서 에러가 발생하였습니다");
@@ -11,22 +15,4 @@ public enum ErrorCode {
     private final String code;
 
     private final String message;
-
-    ErrorCode(HttpStatus httpStatus, String code, String message) {
-        this.httpStatus = httpStatus;
-        this.code = code;
-        this.message = message;
-    }
-
-    public HttpStatus getHttpStatus() {
-        return httpStatus;
-    }
-
-    public String getCode() {
-        return code;
-    }
-
-    public String getMessage() {
-        return message;
-    }
 }

--- a/src/main/java/com/ourmenu/backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/ourmenu/backend/global/exception/ErrorResponse.java
@@ -1,0 +1,13 @@
+package com.ourmenu.backend.global.exception;
+
+public class ErrorResponse {
+
+    private String errorCode;
+
+    private String errorMessage;
+
+    public ErrorResponse(String errorCode, String errorMessage) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/com/ourmenu/backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/ourmenu/backend/global/exception/ErrorResponse.java
@@ -12,4 +12,12 @@ public record ErrorResponse(int status, String code, String message) {
                 .message(errorCode.getMessage())
                 .build();
     }
+
+    public static ErrorResponse of(String message, ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .status(errorCode.getHttpStatus().value())
+                .code(errorCode.getCode())
+                .message(message)
+                .build();
+    }
 }

--- a/src/main/java/com/ourmenu/backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/ourmenu/backend/global/exception/ErrorResponse.java
@@ -1,13 +1,15 @@
 package com.ourmenu.backend.global.exception;
 
-public class ErrorResponse {
+import lombok.Builder;
 
-    private String errorCode;
+@Builder
+public record ErrorResponse(int status, String code, String message) {
 
-    private String errorMessage;
-
-    public ErrorResponse(String errorCode, String errorMessage) {
-        this.errorCode = errorCode;
-        this.errorMessage = errorMessage;
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .status(errorCode.getHttpStatus().value())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .build();
     }
 }

--- a/src/main/java/com/ourmenu/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ourmenu/backend/global/exception/GlobalExceptionHandler.java
@@ -2,10 +2,12 @@ package com.ourmenu.backend.global.exception;
 
 import com.ourmenu.backend.global.response.ApiResponse;
 import com.ourmenu.backend.global.response.util.ApiUtil;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(RuntimeException.class)
@@ -19,6 +21,7 @@ public class GlobalExceptionHandler {
     }
 
     public ApiResponse<?> handleException(Exception e, ErrorResponse errorResponse) {
+        log.error("{}: {}", errorResponse.code(), e.getMessage());
         return ApiUtil.error(errorResponse);
     }
 }

--- a/src/main/java/com/ourmenu/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ourmenu/backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.ourmenu.backend.global.exception;
+
+import com.ourmenu.backend.global.response.ApiResponse;
+import com.ourmenu.backend.global.response.util.ApiUtil;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RuntimeException.class)
+    public ApiResponse<?> handleException(RuntimeException e) {
+        return handleException(e, ErrorResponse.of(ErrorCode.INTERNAL_SERVER));
+    }
+
+    @ExceptionHandler(CustomException.class)
+    public ApiResponse<?> handleCustomException(CustomException e) {
+        return handleException(e, ErrorResponse.of(e.getMessage(), e.getErrorCode()));
+    }
+
+    public ApiResponse<?> handleException(Exception e, ErrorResponse errorResponse) {
+        return ApiUtil.error(errorResponse);
+    }
+}

--- a/src/main/java/com/ourmenu/backend/global/response/ApiResponse.java
+++ b/src/main/java/com/ourmenu/backend/global/response/ApiResponse.java
@@ -1,0 +1,21 @@
+package com.ourmenu.backend.global.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ourmenu.backend.global.exception.ErrorResponse;
+
+public class ApiResponse<T> {
+
+    private final boolean isSuccess;
+
+    @JsonProperty(value = "response")
+    private final T response;
+
+    @JsonProperty(value = "errorResponse")
+    private final ErrorResponse errorResponse;
+
+    public ApiResponse(boolean isSuccess, T response, ErrorResponse errorResponse) {
+        this.isSuccess = isSuccess;
+        this.response = response;
+        this.errorResponse = errorResponse;
+    }
+}

--- a/src/main/java/com/ourmenu/backend/global/response/ApiResponse.java
+++ b/src/main/java/com/ourmenu/backend/global/response/ApiResponse.java
@@ -2,7 +2,9 @@ package com.ourmenu.backend.global.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ourmenu.backend.global.exception.ErrorResponse;
+import lombok.AllArgsConstructor;
 
+@AllArgsConstructor
 public class ApiResponse<T> {
 
     private final boolean isSuccess;
@@ -12,10 +14,4 @@ public class ApiResponse<T> {
 
     @JsonProperty(value = "errorResponse")
     private final ErrorResponse errorResponse;
-
-    public ApiResponse(boolean isSuccess, T response, ErrorResponse errorResponse) {
-        this.isSuccess = isSuccess;
-        this.response = response;
-        this.errorResponse = errorResponse;
-    }
 }

--- a/src/main/java/com/ourmenu/backend/global/response/util/ApiUtil.java
+++ b/src/main/java/com/ourmenu/backend/global/response/util/ApiUtil.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.global.response.util;
 
+import com.ourmenu.backend.global.exception.ErrorResponse;
 import com.ourmenu.backend.global.response.ApiResponse;
 
 public class ApiUtil {
@@ -9,5 +10,9 @@ public class ApiUtil {
 
     public static <T> ApiResponse<T> success(T response) {
         return new ApiResponse<>(true, response, null);
+    }
+
+    public static ApiResponse<?> error(ErrorResponse errorResponse) {
+        return new ApiResponse<>(false, null, errorResponse);
     }
 }

--- a/src/main/java/com/ourmenu/backend/global/response/util/ApiUtil.java
+++ b/src/main/java/com/ourmenu/backend/global/response/util/ApiUtil.java
@@ -1,0 +1,13 @@
+package com.ourmenu.backend.global.response.util;
+
+import com.ourmenu.backend.global.response.ApiResponse;
+
+public class ApiUtil {
+
+    private ApiUtil() {
+    }
+
+    public static <T> ApiResponse<T> success(T response) {
+        return new ApiResponse<>(true, response, null);
+    }
+}


### PR DESCRIPTION
### ✏️ 작업 개요
- #12 

### ⛳ 작업 분류
- [x] global response 추가
- [x] global exception 추가
- [x] exceptionhandler 추가

### 🔨 작업 상세 내용
1. global response, exception을 추가하였습니다, 기존 방식과 거이 동일합니다

### 💡 생각해볼 문제
- 최대한 역활을 생각하면서 구현하였습니다. 결국 전과 동일한 방식과 유사해졌지만 각각 클래스에 어떤 역활을 하고 있는지 생각해보면 좋을 거 같습니다 (예를들어 ErrorCode는 서버 내부에서의 error들의 집합이고, ErrorResponse는 error를 원하는 출력의 형태로 구성하는 역활을 하고 있습니다)
- 로깅형태를 code+message로 구현했습니다 
ex)  `ERROR 11984 --- [backend] [nio-8080-exec-3] c.o.b.g.e.GlobalExceptionHandler         : G500: 에러메세지`
- 클라에게 반환할 error는 서버 내부의 error와 다를 수 있습니다.(서버에서는 클라에서 보이지 않는 더 민감한 메세지를 볼 수 있어야 합니다) 
- 컨벤션 어렵네요. ✈️ 
