### PR TITLE
[Refactor] 예외처리 통일

### DIFF
--- a/src/main/java/com/ourmenu/backend/domain/menu/exception/ForbiddenMenuFolderException.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/exception/ForbiddenMenuFolderException.java
@@ -5,6 +5,6 @@ import com.ourmenu.backend.global.exception.ErrorCode;
 
 public class ForbiddenMenuFolderException extends CustomException {
     public ForbiddenMenuFolderException() {
-        super("소유하고 있는 메뉴판이 아닙니다", ErrorCode.FORBIDDEN_MENU_RESOURCE);
+        super(ErrorCode.FORBIDDEN_MENU_FOLDER);
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/exception/NotFoundMenuFolderException.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/exception/NotFoundMenuFolderException.java
@@ -5,6 +5,6 @@ import com.ourmenu.backend.global.exception.ErrorCode;
 
 public class NotFoundMenuFolderException extends CustomException {
     public NotFoundMenuFolderException() {
-        super("찾을 수 없는 메뉴판입니다", ErrorCode.NOT_FOUND_MENU_RESOURCE);
+        super(ErrorCode.NOT_FOUND_MENU_FOLDER);
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/exception/OutOfBoundCustomIndexException.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/exception/OutOfBoundCustomIndexException.java
@@ -5,6 +5,6 @@ import com.ourmenu.backend.global.exception.ErrorCode;
 
 public class OutOfBoundCustomIndexException extends CustomException {
     public OutOfBoundCustomIndexException() {
-        super("현재 메뉴판이 가지고 있는 최대 인덱스를 벗어납니다", ErrorCode.MENU_INTERNAL_SERVER);
+        super(ErrorCode.OUT_OF_BOUND_CUSTOM_INDEX);
     }
 }

--- a/src/main/java/com/ourmenu/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/ourmenu/backend/global/exception/ErrorCode.java
@@ -21,9 +21,9 @@ public enum ErrorCode {
     NOT_MATCH_TOKEN(HttpStatus.UNAUTHORIZED, "U401", "유저의 토큰값과 일치하지 않습니다."),
 
     // 메뉴판
-    FORBIDDEN_MENU_RESOURCE(HttpStatus.FORBIDDEN, "M403", "접근할 수 없는 메뉴 리소스입니다"),
-    NOT_FOUND_MENU_RESOURCE(HttpStatus.NOT_FOUND, "M404", "찾을 수 없는 메뉴 리소스입니다"),
-    MENU_INTERNAL_SERVER(HttpStatus.INTERNAL_SERVER_ERROR, "M500", "메뉴 서버 로직 내부에서 에러가 발생하였습니다"),
+    FORBIDDEN_MENU_FOLDER(HttpStatus.FORBIDDEN, "F403", "소유하고 있는 메뉴판이 아닙니다"),
+    NOT_FOUND_MENU_FOLDER(HttpStatus.NOT_FOUND, "F404", "찾을 수 없는 메뉴 리소스입니다"),
+    OUT_OF_BOUND_CUSTOM_INDEX(HttpStatus.INTERNAL_SERVER_ERROR, "F500", "현재 메뉴판이 가지고 있는 최대 인덱스를 벗어납니다"),
 
     // S3
     UPLOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "A500", "파일 업로드중 문제가 발생하였습니다"),


### PR DESCRIPTION
### ✏️ 작업 개요
- ErrorCode 처리 통일

### ⛳ 작업 분류
- [x] ErrorCode 처리 통일

### 🔨 작업 상세 내용
1. 회의에 결정난대로 ErrorCode에서 모든 예외 메세지를 정의하고 커스텀해서 사용하지 않도록 변경하였습니다
2. 메뉴판 관련 에러코드를 M500 ->F500 으로 바꾸었습니다 (Folder 이니셜 사용, 메뉴와 M이 중복되기 때문에)

### 💡 생각해볼 문제
- X
