### PR TITLE
[Feat] BaseEntity 추가, 지연로딩 추가

### DIFF
--- a/src/main/java/com/ourmenu/backend/domain/menu/domain/Menu.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/domain/Menu.java
@@ -3,6 +3,7 @@ package com.ourmenu.backend.domain.menu.domain;
 import com.ourmenu.backend.domain.store.domain.Store;
 import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -40,6 +41,6 @@ public class Menu extends BaseEntity {
     @NotNull
     private Long userId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Store store;
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/domain/Menu.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/domain/Menu.java
@@ -1,6 +1,7 @@
 package com.ourmenu.backend.domain.menu.domain;
 
 import com.ourmenu.backend.domain.store.domain.Store;
+import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Getter
-public class Menu {
+public class Menu extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ourmenu/backend/domain/menu/domain/MenuFolder.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/domain/MenuFolder.java
@@ -1,6 +1,7 @@
 package com.ourmenu.backend.domain.menu.domain;
 
 import com.ourmenu.backend.domain.menu.dto.MenuFolderDto;
+import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Getter
-public class MenuFolder {
+public class MenuFolder extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ourmenu/backend/domain/menu/domain/MenuImg.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/domain/MenuImg.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.domain;
 
+import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Getter
-public class MenuImg {
+public class MenuImg extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ourmenu/backend/domain/menu/domain/MenuMenuFolder.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/domain/MenuMenuFolder.java
@@ -2,6 +2,7 @@ package com.ourmenu.backend.domain.menu.domain;
 
 import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,7 +26,7 @@ public class MenuMenuFolder extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Menu menu;
 
     private Long folderId;

--- a/src/main/java/com/ourmenu/backend/domain/menu/domain/MenuMenuFolder.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/domain/MenuMenuFolder.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.domain;
 
+import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Getter
-public class MenuMenuFolder {
+public class MenuMenuFolder extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/NotFoundStore.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/NotFoundStore.java
@@ -3,6 +3,7 @@ package com.ourmenu.backend.domain.search.domain;
 import com.ourmenu.backend.domain.store.domain.Store;
 import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -37,6 +38,6 @@ public class NotFoundStore extends BaseEntity {
     @NotNull
     private Double mapY;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Store store;
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/NotFoundStore.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/NotFoundStore.java
@@ -1,6 +1,7 @@
 package com.ourmenu.backend.domain.search.domain;
 
 import com.ourmenu.backend.domain.store.domain.Store;
+import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Getter
-public class NotFoundStore {
+public class NotFoundStore extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/NotOwnedMenuSearch.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/NotOwnedMenuSearch.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.search.domain;
 
+import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Getter
-public class NotOwnedMenuSearch {
+public class NotOwnedMenuSearch extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/OwnedMenuSearch.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/OwnedMenuSearch.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.search.domain;
 
+import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Getter
-public class OwnedMenuSearch {
+public class OwnedMenuSearch extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ourmenu/backend/domain/store/domain/Map.java
+++ b/src/main/java/com/ourmenu/backend/domain/store/domain/Map.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.store.domain;
 
+import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Getter
-public class Map {
+public class Map extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ourmenu/backend/domain/store/domain/Map.java
+++ b/src/main/java/com/ourmenu/backend/domain/store/domain/Map.java
@@ -2,6 +2,7 @@ package com.ourmenu.backend.domain.store.domain;
 
 import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -30,6 +31,6 @@ public class Map extends BaseEntity {
     @NotNull
     private Double mapY;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Store store;
 }

--- a/src/main/java/com/ourmenu/backend/domain/store/domain/Store.java
+++ b/src/main/java/com/ourmenu/backend/domain/store/domain/Store.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.store.domain;
 
+import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Getter
-public class Store {
+public class Store extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ourmenu/backend/domain/tag/domain/MenuTag.java
+++ b/src/main/java/com/ourmenu/backend/domain/tag/domain/MenuTag.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.tag.domain;
 
+import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Getter
-public class MenuTag {
+public class MenuTag extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ourmenu/backend/domain/tag/domain/MenuTag.java
+++ b/src/main/java/com/ourmenu/backend/domain/tag/domain/MenuTag.java
@@ -2,6 +2,7 @@ package com.ourmenu.backend.domain.tag.domain;
 
 import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,6 +28,6 @@ public class MenuTag extends BaseEntity {
     @NotNull
     private Long menuId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Tag tag;
 }

--- a/src/main/java/com/ourmenu/backend/domain/tag/domain/Tag.java
+++ b/src/main/java/com/ourmenu/backend/domain/tag/domain/Tag.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.tag.domain;
 
+import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Getter
-public class Tag {
+public class Tag extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ourmenu/backend/domain/user/domain/MealTime.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/domain/MealTime.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.user.domain;
 
+import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -14,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class MealTime {
+public class MealTime extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ourmenu/backend/domain/user/domain/User.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/domain/User.java
@@ -1,6 +1,10 @@
 package com.ourmenu.backend.domain.user.domain;
 
-import jakarta.persistence.*;
+import com.ourmenu.backend.global.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class User{
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,7 +27,7 @@ public class User{
 
     private SignInType signInType;
 
-    public void changePassword(String newPassword){
+    public void changePassword(String newPassword) {
         this.password = newPassword;
     }
 }

--- a/src/main/java/com/ourmenu/backend/global/config/BaseEntityConfig.java
+++ b/src/main/java/com/ourmenu/backend/global/config/BaseEntityConfig.java
@@ -1,0 +1,9 @@
+package com.ourmenu.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class BaseEntityConfig {
+}

--- a/src/main/java/com/ourmenu/backend/global/domain/BaseEntity.java
+++ b/src/main/java/com/ourmenu/backend/global/domain/BaseEntity.java
@@ -1,0 +1,21 @@
+package com.ourmenu.backend.global.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}


### PR DESCRIPTION
### ✏️ 작업 개요
- #11 

### ⛳ 작업 분류
- [x] BaseEntity 추가
- [x] 지연로딩 추가

### 🔨 작업 상세 내용
1. BaseEntity 사용을 제안하고자 합니다.
2. created at, modified at 컬럼을 `AuditingEntityListener` 를 통해 삽입, 수정되는 경우에 해당 시간으로 저장하도록 합니다.
3. 기존에 있는 모든 엔티티에 적용하였습니다.
4. 다대일 연관관계에 대해서 지연로딩을 적용하였습니다. (의도했던 것은 아니고 깜박했습니다..)
 
### 💡 생각해볼 문제
- 개발중에 이렇게 추가적으로 PR이 필요한 경우 issue를 파서 브랜치에 작업을 해야할지, isssue없이 브랜치로만 작업할지, 기존에 있는 브랜치로 작업하는게 좋은지 정하면 좋겠어요(이번에는 운좋게 적합한 브랜치가 이미 있었어요)
