### PR TITLE
[Feat] 메뉴 검색 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,18 +42,21 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
-	//Redis
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.session:spring-session-data-redis'
+    //Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
 
-	//Mail
-	implementation 'org.springframework.boot:spring-boot-starter-mail'
+    //Mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     //Validator
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     //AWS s3 sdk
     implementation 'software.amazon.awssdk:s3:2.29.23'
+
+    //mongodb
+    implementation('org.springframework.boot:spring-boot-starter-data-mongodb')
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 
     //mongodb
     implementation('org.springframework.boot:spring-boot-starter-data-mongodb')
+
+    //webflux(Webclient)
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ourmenu/backend/domain/search/api/SearchController.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/api/SearchController.java
@@ -1,0 +1,27 @@
+package com.ourmenu.backend.domain.search.api;
+
+import com.ourmenu.backend.domain.search.application.SearchService;
+import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
+import com.ourmenu.backend.global.response.ApiResponse;
+import com.ourmenu.backend.global.response.util.ApiUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @GetMapping("/priored/stores/menus")
+    public ApiResponse<Void> searchStore(@RequestParam(name = "query") String query,
+                                         @AuthenticationPrincipal CustomUserDetails userDetails) {
+        searchService.searchStore(userDetails.getId(), query);
+        return ApiUtil.successOnly();
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/search/api/SearchController.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/api/SearchController.java
@@ -1,12 +1,16 @@
 package com.ourmenu.backend.domain.search.api;
 
 import com.ourmenu.backend.domain.search.application.SearchService;
+import com.ourmenu.backend.domain.search.dto.GetStoreResponse;
 import com.ourmenu.backend.domain.search.dto.SearchStoreResponse;
+import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
 import com.ourmenu.backend.global.response.ApiResponse;
 import com.ourmenu.backend.global.response.util.ApiUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,6 +25,14 @@ public class SearchController {
     @GetMapping("/priored/stores/menus")
     public ApiResponse<List<SearchStoreResponse>> searchStore(@RequestParam(name = "query") String query) {
         List<SearchStoreResponse> response = searchService.searchStore(query);
+        return ApiUtil.success(response);
+    }
+
+    @GetMapping("/priored/stores/{storeId}")
+    public ApiResponse<GetStoreResponse> getStore(@RequestParam(name = "is-crawled") boolean isCrawled,
+                                                  @PathVariable(name = "storeId") String storeId,
+                                                  @AuthenticationPrincipal CustomUserDetails userDetails) {
+        GetStoreResponse response = searchService.getStore(userDetails.getId(), isCrawled, storeId);
         return ApiUtil.success(response);
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/api/SearchController.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/api/SearchController.java
@@ -1,6 +1,7 @@
 package com.ourmenu.backend.domain.search.api;
 
 import com.ourmenu.backend.domain.search.application.SearchService;
+import com.ourmenu.backend.domain.search.dto.GetSearchHistoryResponse;
 import com.ourmenu.backend.domain.search.dto.GetStoreResponse;
 import com.ourmenu.backend.domain.search.dto.SearchStoreResponse;
 import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
@@ -33,6 +34,12 @@ public class SearchController {
                                                   @PathVariable(name = "storeId") String storeId,
                                                   @AuthenticationPrincipal CustomUserDetails userDetails) {
         GetStoreResponse response = searchService.getStore(userDetails.getId(), isCrawled, storeId);
+        return ApiUtil.success(response);
+    }
+
+    @GetMapping("priored/users/{userId}/histories")
+    public ApiResponse<List<GetSearchHistoryResponse>> getSearchHistory(@PathVariable(name = "userId") Long userId){
+        List<GetSearchHistoryResponse> response = searchService.getSearchHistory(userId);
         return ApiUtil.success(response);
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/api/SearchController.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/api/SearchController.java
@@ -1,11 +1,11 @@
 package com.ourmenu.backend.domain.search.api;
 
 import com.ourmenu.backend.domain.search.application.SearchService;
-import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
+import com.ourmenu.backend.domain.search.dto.SearchStoreResponse;
 import com.ourmenu.backend.global.response.ApiResponse;
 import com.ourmenu.backend.global.response.util.ApiUtil;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -19,9 +19,8 @@ public class SearchController {
     private final SearchService searchService;
 
     @GetMapping("/priored/stores/menus")
-    public ApiResponse<Void> searchStore(@RequestParam(name = "query") String query,
-                                         @AuthenticationPrincipal CustomUserDetails userDetails) {
-        searchService.searchStore(userDetails.getId(), query);
-        return ApiUtil.successOnly();
+    public ApiResponse<List<SearchStoreResponse>> searchStore(@RequestParam(name = "query") String query) {
+        List<SearchStoreResponse> response = searchService.searchStore(query);
+        return ApiUtil.success(response);
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/application/KakaoApiService.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/application/KakaoApiService.java
@@ -1,0 +1,13 @@
+package com.ourmenu.backend.domain.search.application;
+
+import com.ourmenu.backend.domain.search.domain.NotFoundStore;
+import org.springframework.stereotype.Service;
+
+@Service
+public class KakaoApiService {
+
+
+    public NotFoundStore searchKakaoMap(String query) {
+        return null;
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/search/application/KakaoApiService.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/application/KakaoApiService.java
@@ -1,13 +1,46 @@
 package com.ourmenu.backend.domain.search.application;
 
 import com.ourmenu.backend.domain.search.domain.NotFoundStore;
+import com.ourmenu.backend.domain.search.dto.KaKaoMapDto;
+import com.ourmenu.backend.domain.search.dto.KakaoAPIResponse;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
+
 public class KakaoApiService {
 
+    @Value("${kakao.APIKey}")
+    private String kakaoAPIKey;
+    private WebClient webClient;
+
+    @PostConstruct
+    public void initWebClient() {
+        webClient = WebClient.builder()
+                .baseUrl("https://dapi.kakao.com/v2/local/search/keyword.json")
+                .defaultHeader("Authorization", kakaoAPIKey)
+                .build();
+    }
 
     public NotFoundStore searchKakaoMap(String query) {
-        return null;
+        KakaoAPIResponse response = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("query", query)
+                        .queryParam("size", 1)
+                        .build()
+                )
+                .retrieve()
+                .bodyToMono(KakaoAPIResponse.class)
+                .block();
+        KaKaoMapDto kaKaoMapDto = response.getDocuments()[0];
+        return NotFoundStore.builder()
+                .title(kaKaoMapDto.getPlaceName())
+                .address(kaKaoMapDto.getAddressName())
+                .mapX(kaKaoMapDto.getMapX())
+                .mapY(kaKaoMapDto.getMapY())
+                .storeId(kaKaoMapDto.getStoreId())
+                .build();
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/application/SearchService.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/application/SearchService.java
@@ -6,6 +6,7 @@ import com.ourmenu.backend.domain.search.domain.NotFoundStore;
 import com.ourmenu.backend.domain.search.domain.SearchableStore;
 import com.ourmenu.backend.domain.search.dto.SearchStoreResponse;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -18,8 +19,15 @@ public class SearchService {
 
     private final SearchableStoreRepository searchableStoreRepository;
     private final NotFoundStoreRepository notFoundStoreRepository;
+    private final KakaoApiService kakaoApiService;
 
-    @Transactional(readOnly = true)
+    /**
+     * 몽고DB -> mysql -> kakaoAPI 순으로 검색한다
+     *
+     * @param query
+     * @return
+     */
+    @Transactional
     public List<SearchStoreResponse> searchStore(String query) {
         PageRequest pageRequest = PageRequest.of(0, 10);
         List<SearchableStore> searchableStores = searchableStoreRepository.findByMenuNameOrStoreNameContaining(
@@ -45,10 +53,16 @@ public class SearchService {
                 .toList();
     }
 
+    /**
+     * mysql에 식당 정보를 검색한다. mysql에는 이전 Kakao API 통신의 일부를 저장하고 있다.
+     *
+     * @param query
+     * @return
+     */
     private List<SearchStoreResponse> searchCacheEntity(String query) {
         List<NotFoundStore> notFoundStores = notFoundStoreRepository.findByTitleContaining(query);
         if (notFoundStores.size() == 0) {
-            return searchByKakaoApi(query);
+            return searchByKakaoApiAndSave(query);
         }
         return notFoundStores.stream()
                 .limit(5)
@@ -56,7 +70,23 @@ public class SearchService {
                 .toList();
     }
 
-    private List<SearchStoreResponse> searchByKakaoApi(String query) {
+    /**
+     * Kakao API로 검색후 mysql에 없다면 저장하고 반환한다.
+     *
+     * @param query
+     * @return
+     */
+    private List<SearchStoreResponse> searchByKakaoApiAndSave(String query) {
+        NotFoundStore notFoundStore = kakaoApiService.searchKakaoMap(query);
 
+        Optional<NotFoundStore> optionalNotFoundStore = notFoundStoreRepository.findByStoreId(
+                notFoundStore.getStoreId());
+        if (optionalNotFoundStore.isPresent()) {
+            notFoundStore = optionalNotFoundStore.get();
+            return List.of(SearchStoreResponse.from(notFoundStore));
+        }
+
+        notFoundStore = notFoundStoreRepository.save(notFoundStore);
+        return List.of(SearchStoreResponse.from(notFoundStore));
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/application/SearchService.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/application/SearchService.java
@@ -1,0 +1,37 @@
+package com.ourmenu.backend.domain.search.application;
+
+import com.ourmenu.backend.domain.search.dao.SearchableStoreRepository;
+import com.ourmenu.backend.domain.search.domain.SearchableStore;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+    private final SearchableStoreRepository searchableStoreRepository;
+
+    @Transactional(readOnly = true)
+    public List<SearchableStore> searchStore(Long userId, String query) {
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        List<SearchableStore> searchableStores = searchableStoreRepository.findByMenuNameOrStoreNameContaining(
+                query, pageRequest);
+
+        //가게 이름 우선적으로 필터링
+        List<SearchableStore> storesWithNameMatch = searchableStores.stream()
+                .filter(store -> store.getTitle().contains(query))
+                .collect(Collectors.toList());
+
+        //메뉴 이름은 후순위
+        List<SearchableStore> otherStores = searchableStores.stream()
+                .filter(store -> !store.getTitle().contains(query))
+                .toList();
+        storesWithNameMatch.addAll(otherStores);
+
+        return storesWithNameMatch.stream().limit(5).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/search/application/SearchService.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/application/SearchService.java
@@ -4,6 +4,7 @@ import com.ourmenu.backend.domain.search.dao.NotFoundStoreRepository;
 import com.ourmenu.backend.domain.search.dao.SearchableStoreRepository;
 import com.ourmenu.backend.domain.search.domain.NotFoundStore;
 import com.ourmenu.backend.domain.search.domain.SearchableStore;
+import com.ourmenu.backend.domain.search.dto.GetStoreResponse;
 import com.ourmenu.backend.domain.search.dto.SearchStoreResponse;
 import java.util.List;
 import java.util.Optional;
@@ -54,6 +55,24 @@ public class SearchService {
     }
 
     /**
+     * 가게 검색
+     *
+     * @param userId
+     * @param isCrawled true(몽고DB), false(mysql)
+     * @param storeId
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public GetStoreResponse getStore(Long userId, boolean isCrawled, String storeId) {
+        if (isCrawled) {
+            SearchableStore searchableStore = findByStoreId(storeId);
+            return GetStoreResponse.from(searchableStore);
+        }
+        NotFoundStore cacheEntityByStoreId = findCacheEntityByStoreId(storeId);
+        return GetStoreResponse.from(cacheEntityByStoreId);
+    }
+
+    /**
      * mysql에 식당 정보를 검색한다. mysql에는 이전 Kakao API 통신의 일부를 저장하고 있다.
      *
      * @param query
@@ -88,5 +107,13 @@ public class SearchService {
 
         notFoundStore = notFoundStoreRepository.save(notFoundStore);
         return List.of(SearchStoreResponse.from(notFoundStore));
+    }
+
+    private SearchableStore findByStoreId(String storeId) {
+        return searchableStoreRepository.findByStoreId(storeId).get();
+    }
+
+    private NotFoundStore findCacheEntityByStoreId(String storeId) {
+        return notFoundStoreRepository.findByStoreId(storeId).get();
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/application/SearchService.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/application/SearchService.java
@@ -6,6 +6,7 @@ import com.ourmenu.backend.domain.search.dao.SearchableStoreRepository;
 import com.ourmenu.backend.domain.search.domain.NotFoundStore;
 import com.ourmenu.backend.domain.search.domain.NotOwnedMenuSearch;
 import com.ourmenu.backend.domain.search.domain.SearchableStore;
+import com.ourmenu.backend.domain.search.dto.GetSearchHistoryResponse;
 import com.ourmenu.backend.domain.search.dto.GetStoreResponse;
 import com.ourmenu.backend.domain.search.dto.SearchStoreResponse;
 import java.util.List;
@@ -78,6 +79,21 @@ public class SearchService {
         GetStoreResponse response = GetStoreResponse.from(cacheEntityByStoreId);
         saveSearchHistory(userId,response);
         return response;
+    }
+
+    /**
+     * 메뉴 검색 기록 조회
+     * 유저가 소유하지 메뉴
+     * @param userId
+     * @return
+     */
+    @Transactional
+    public List<GetSearchHistoryResponse> getSearchHistory(Long userId){
+        List<NotOwnedMenuSearch> notOwnedMenuSearches = notOwnedMenuSearchRepository.findByUserIdOrderByModifiedAtDesc(
+                userId);
+        return notOwnedMenuSearches.stream()
+                .map(GetSearchHistoryResponse::from)
+                .toList();
     }
 
     /**

--- a/src/main/java/com/ourmenu/backend/domain/search/application/SearchService.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/application/SearchService.java
@@ -2,6 +2,7 @@ package com.ourmenu.backend.domain.search.application;
 
 import com.ourmenu.backend.domain.search.dao.SearchableStoreRepository;
 import com.ourmenu.backend.domain.search.domain.SearchableStore;
+import com.ourmenu.backend.domain.search.dto.SearchStoreResponse;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +17,7 @@ public class SearchService {
     private final SearchableStoreRepository searchableStoreRepository;
 
     @Transactional(readOnly = true)
-    public List<SearchableStore> searchStore(Long userId, String query) {
+    public List<SearchStoreResponse> searchStore(String query) {
         PageRequest pageRequest = PageRequest.of(0, 10);
         List<SearchableStore> searchableStores = searchableStoreRepository.findByMenuNameOrStoreNameContaining(
                 query, pageRequest);
@@ -32,6 +33,9 @@ public class SearchService {
                 .toList();
         storesWithNameMatch.addAll(otherStores);
 
-        return storesWithNameMatch.stream().limit(5).collect(Collectors.toList());
+        return storesWithNameMatch.stream()
+                .limit(5)
+                .map(SearchStoreResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/dao/NotFoundStoreRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dao/NotFoundStoreRepository.java
@@ -1,0 +1,12 @@
+package com.ourmenu.backend.domain.search.dao;
+
+import com.ourmenu.backend.domain.search.domain.NotFoundStore;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotFoundStoreRepository extends JpaRepository<NotFoundStore, Long> {
+
+    List<NotFoundStore> findByTitleContaining(String title);
+}

--- a/src/main/java/com/ourmenu/backend/domain/search/dao/NotFoundStoreRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dao/NotFoundStoreRepository.java
@@ -2,6 +2,7 @@ package com.ourmenu.backend.domain.search.dao;
 
 import com.ourmenu.backend.domain.search.domain.NotFoundStore;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface NotFoundStoreRepository extends JpaRepository<NotFoundStore, Long> {
 
     List<NotFoundStore> findByTitleContaining(String title);
+
+    Optional<NotFoundStore> findByStoreId(String storeId);
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/dao/NotOwnedMenuSearchRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dao/NotOwnedMenuSearchRepository.java
@@ -1,9 +1,12 @@
 package com.ourmenu.backend.domain.search.dao;
 
 import com.ourmenu.backend.domain.search.domain.NotOwnedMenuSearch;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NotOwnedMenuSearchRepository extends JpaRepository<NotOwnedMenuSearch,Long> {
+
+    List<NotOwnedMenuSearch>findByUserIdOrderByModifiedAtDesc(Long userId);
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/dao/NotOwnedMenuSearchRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dao/NotOwnedMenuSearchRepository.java
@@ -1,0 +1,9 @@
+package com.ourmenu.backend.domain.search.dao;
+
+import com.ourmenu.backend.domain.search.domain.NotOwnedMenuSearch;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotOwnedMenuSearchRepository extends JpaRepository<NotOwnedMenuSearch,Long> {
+}

--- a/src/main/java/com/ourmenu/backend/domain/search/dao/SearchableStoreRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dao/SearchableStoreRepository.java
@@ -1,12 +1,12 @@
 package com.ourmenu.backend.domain.search.dao;
 
 import com.ourmenu.backend.domain.search.domain.SearchableStore;
-import java.util.Optional;
+import java.util.List;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SearchableStoreRepository extends MongoRepository<SearchableStore, String> {
 
-    Optional<SearchableStore> findByNameContaining(String name);
+    List<SearchableStore> findAllByNameContaining(String name);
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/dao/SearchableStoreRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dao/SearchableStoreRepository.java
@@ -2,6 +2,7 @@ package com.ourmenu.backend.domain.search.dao;
 
 import com.ourmenu.backend.domain.search.domain.SearchableStore;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
@@ -12,4 +13,6 @@ public interface SearchableStoreRepository extends MongoRepository<SearchableSto
 
     @Query("{ '$or': [ { 'menus.menuName': { $regex: ?0, $options: 'i' } }, { 'name': { $regex: ?0, $options: 'i' } } ] }")
     List<SearchableStore> findByMenuNameOrStoreNameContaining(String keyword, Pageable pageable);
+
+    Optional<SearchableStore> findByStoreId(String storeId);
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/dao/SearchableStoreRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dao/SearchableStoreRepository.java
@@ -1,0 +1,12 @@
+package com.ourmenu.backend.domain.search.dao;
+
+import com.ourmenu.backend.domain.search.domain.SearchableStore;
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SearchableStoreRepository extends MongoRepository<SearchableStore, String> {
+
+    Optional<SearchableStore> findByNameContaining(String name);
+}

--- a/src/main/java/com/ourmenu/backend/domain/search/dao/SearchableStoreRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dao/SearchableStoreRepository.java
@@ -2,11 +2,14 @@ package com.ourmenu.backend.domain.search.dao;
 
 import com.ourmenu.backend.domain.search.domain.SearchableStore;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SearchableStoreRepository extends MongoRepository<SearchableStore, String> {
 
-    List<SearchableStore> findAllByNameContaining(String name);
+    @Query("{ '$or': [ { 'menus.menuName': { $regex: ?0, $options: 'i' } }, { 'name': { $regex: ?0, $options: 'i' } } ] }")
+    List<SearchableStore> findByMenuNameOrStoreNameContaining(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/NotFoundStore.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/NotFoundStore.java
@@ -34,4 +34,6 @@ public class NotFoundStore extends BaseEntity {
 
     @NotNull
     private Double mapY;
+
+    private String storeId;
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/NotFoundStore.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/NotFoundStore.java
@@ -1,13 +1,10 @@
 package com.ourmenu.backend.domain.search.domain;
 
-import com.ourmenu.backend.domain.store.domain.Store;
 import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -37,7 +34,4 @@ public class NotFoundStore extends BaseEntity {
 
     @NotNull
     private Double mapY;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Store store;
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/NotOwnedMenuSearch.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/NotOwnedMenuSearch.java
@@ -15,7 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "user_owned_search_history")
+@Table(name = "not_owned_search_history")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -30,7 +30,7 @@ public class NotOwnedMenuSearch extends BaseEntity {
     private String title;
 
     @NotNull
-    private LocalDateTime searchAt;
+    private String address;
 
     @NotNull
     private Long userId;

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/SearchableStore.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/SearchableStore.java
@@ -1,0 +1,41 @@
+package com.ourmenu.backend.domain.search.domain;
+
+import com.ourmenu.backend.domain.menu.domain.Menu;
+import jakarta.persistence.Column;
+import jakarta.persistence.Id;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Document(collection = "store")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class SearchableStore {
+
+    @Id
+    private String id;
+
+    private String name;
+
+    private List<String> images;
+
+    @Column(name = "menus")
+    private List<Menu> menu;
+
+    private String type;
+
+    @Field(name = "도로명주소 ")
+    private String roadNameAddress;
+
+    @Field(name = "지번주소")
+    private String groundNameAddress;
+
+    private Double mapX;
+
+    private Double mapY;
+}

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/SearchableStore.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/SearchableStore.java
@@ -22,4 +22,6 @@ public class SearchableStore {
     @Field(name = "menus")
     private List<StoreMenu> storeMenus;
     private String storeId;
+    private Double mapX;
+    private Double mapY;
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/SearchableStore.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/SearchableStore.java
@@ -12,7 +12,8 @@ public class SearchableStore {
 
     @Id
     private String id;
-    private String name;
+    @Field(name = "name")
+    private String title;
     private String address;
     @Field(name = "images")
     private List<String> storeImgs;

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/SearchableStore.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/SearchableStore.java
@@ -2,11 +2,13 @@ package com.ourmenu.backend.domain.search.domain;
 
 import jakarta.persistence.Id;
 import java.util.List;
+import lombok.Getter;
 import lombok.ToString;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "store")
+@Getter
 @ToString
 public class SearchableStore {
 

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/SearchableStore.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/SearchableStore.java
@@ -1,41 +1,22 @@
 package com.ourmenu.backend.domain.search.domain;
 
-import com.ourmenu.backend.domain.menu.domain.Menu;
-import jakarta.persistence.Column;
 import jakarta.persistence.Id;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "store")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Getter
+@ToString
 public class SearchableStore {
 
     @Id
     private String id;
-
     private String name;
-
-    private List<String> images;
-
-    @Column(name = "menus")
-    private List<Menu> menu;
-
-    private String type;
-
-    @Field(name = "도로명주소 ")
-    private String roadNameAddress;
-
-    @Field(name = "지번주소")
-    private String groundNameAddress;
-
-    private Double mapX;
-
-    private Double mapY;
+    private String address;
+    @Field(name = "images")
+    private List<String> storeImgs;
+    @Field(name = "menus")
+    private List<StoreMenu> storeMenus;
+    private String storeId;
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/StoreMenu.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/StoreMenu.java
@@ -1,0 +1,17 @@
+package com.ourmenu.backend.domain.search.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@NoArgsConstructor
+@Getter
+@ToString
+public class StoreMenu {
+
+    @Field(name = "menuName")
+    private String name;
+    @Field(name = "menuPrice")
+    private String price;
+}

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/StoreMenu.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/StoreMenu.java
@@ -11,7 +11,7 @@ import org.springframework.data.mongodb.core.mapping.Field;
 public class StoreMenu {
 
     @Field(name = "menuName")
-    private String name;
+    private String title;
     @Field(name = "menuPrice")
     private String price;
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/dto/GetSearchHistoryResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dto/GetSearchHistoryResponse.java
@@ -1,0 +1,28 @@
+package com.ourmenu.backend.domain.search.dto;
+
+import com.ourmenu.backend.domain.search.domain.NotOwnedMenuSearch;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class GetSearchHistoryResponse {
+
+    private String menuTitle;
+
+    private String storeAddress;
+
+    private LocalDateTime modifiedAt;
+
+    public static GetSearchHistoryResponse from(NotOwnedMenuSearch notOwnedMenuSearch){
+        return GetSearchHistoryResponse.builder()
+                .menuTitle(notOwnedMenuSearch.getTitle())
+                .storeAddress(notOwnedMenuSearch.getAddress())
+                .modifiedAt(notOwnedMenuSearch.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/search/dto/GetStoreMenuResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dto/GetStoreMenuResponse.java
@@ -1,0 +1,23 @@
+package com.ourmenu.backend.domain.search.dto;
+
+import com.ourmenu.backend.domain.search.domain.StoreMenu;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class GetStoreMenuResponse {
+
+    private String menuTitle;
+    private String menuPrice;
+
+    public static GetStoreMenuResponse from(StoreMenu storeMenu) {
+        return GetStoreMenuResponse.builder()
+                .menuTitle(storeMenu.getTitle())
+                .menuPrice(storeMenu.getPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/search/dto/GetStoreResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dto/GetStoreResponse.java
@@ -1,0 +1,52 @@
+package com.ourmenu.backend.domain.search.dto;
+
+import com.ourmenu.backend.domain.search.domain.NotFoundStore;
+import com.ourmenu.backend.domain.search.domain.SearchableStore;
+import com.ourmenu.backend.domain.search.util.UrlUtil;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class GetStoreResponse {
+
+    private String storeId;
+    private String storeTitle;
+    private String storeAddress;
+    private List<String> storeImgs;
+    private List<GetStoreMenuResponse> menus;
+    private Double storeMapX;
+    private Double storeMapY;
+
+    public static GetStoreResponse from(SearchableStore searchableStore) {
+        List<GetStoreMenuResponse> getStoreMenuResponses = searchableStore.getStoreMenus().stream()
+                .map(GetStoreMenuResponse::from)
+                .toList();
+        List<String> imgUrls = searchableStore.getStoreImgs().stream()
+                .map(UrlUtil::parseStoreImgUrl)
+                .toList();
+        return GetStoreResponse.builder()
+                .storeId(searchableStore.getStoreId())
+                .storeTitle(searchableStore.getTitle())
+                .storeAddress(searchableStore.getAddress())
+                .storeImgs(imgUrls)
+                .menus(getStoreMenuResponses)
+                .storeMapX(searchableStore.getMapX())
+                .storeMapY(searchableStore.getMapY())
+                .build();
+    }
+
+    public static GetStoreResponse from(NotFoundStore notFoundStore) {
+        return GetStoreResponse.builder()
+                .storeId(notFoundStore.getStoreId())
+                .storeTitle(notFoundStore.getTitle())
+                .storeAddress(notFoundStore.getAddress())
+                .storeMapX(notFoundStore.getMapX())
+                .storeMapY(notFoundStore.getMapY())
+                .build();
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/search/dto/KaKaoMapDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dto/KaKaoMapDto.java
@@ -1,0 +1,27 @@
+package com.ourmenu.backend.domain.search.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor
+@Getter
+@ToString
+public class KaKaoMapDto {
+
+    @JsonProperty("address_name")
+    private String addressName;
+
+    @JsonProperty("place_name")
+    private String placeName;
+
+    @JsonProperty("x")
+    private Double mapX;
+
+    @JsonProperty("y")
+    private Double mapY;
+
+    @JsonProperty("id")
+    private String storeId;
+}

--- a/src/main/java/com/ourmenu/backend/domain/search/dto/KakaoAPIResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dto/KakaoAPIResponse.java
@@ -1,0 +1,10 @@
+package com.ourmenu.backend.domain.search.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class KakaoAPIResponse {
+    private KaKaoMapDto[] documents;
+}

--- a/src/main/java/com/ourmenu/backend/domain/search/dto/SearchStoreResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dto/SearchStoreResponse.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.search.dto;
 
+import com.ourmenu.backend.domain.search.domain.NotFoundStore;
 import com.ourmenu.backend.domain.search.domain.SearchableStore;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -20,6 +21,13 @@ public class SearchStoreResponse {
         return SearchStoreResponse.builder()
                 .storeTitle(searchableStore.getTitle())
                 .storeAddress(searchableStore.getAddress())
+                .build();
+    }
+
+    public static SearchStoreResponse from(NotFoundStore notFoundStore) {
+        return SearchStoreResponse.builder()
+                .storeTitle(notFoundStore.getTitle())
+                .storeAddress(notFoundStore.getAddress())
                 .build();
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/dto/SearchStoreResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dto/SearchStoreResponse.java
@@ -16,11 +16,15 @@ public class SearchStoreResponse {
 
     private String storeTitle;
     private String storeAddress;
+    private boolean isCrawled;
+    private String storeId;
 
     public static SearchStoreResponse from(SearchableStore searchableStore) {
         return SearchStoreResponse.builder()
                 .storeTitle(searchableStore.getTitle())
                 .storeAddress(searchableStore.getAddress())
+                .isCrawled(true)
+                .storeId(searchableStore.getStoreId())
                 .build();
     }
 
@@ -28,6 +32,8 @@ public class SearchStoreResponse {
         return SearchStoreResponse.builder()
                 .storeTitle(notFoundStore.getTitle())
                 .storeAddress(notFoundStore.getAddress())
+                .isCrawled(false)
+                .storeId(notFoundStore.getStoreId())
                 .build();
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/dto/SearchStoreResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dto/SearchStoreResponse.java
@@ -1,0 +1,25 @@
+package com.ourmenu.backend.domain.search.dto;
+
+import com.ourmenu.backend.domain.search.domain.SearchableStore;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+@ToString
+public class SearchStoreResponse {
+
+    private String storeTitle;
+    private String storeAddress;
+
+    public static SearchStoreResponse from(SearchableStore searchableStore) {
+        return SearchStoreResponse.builder()
+                .storeTitle(searchableStore.getTitle())
+                .storeAddress(searchableStore.getAddress())
+                .build();
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/search/util/UrlUtil.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/util/UrlUtil.java
@@ -1,0 +1,15 @@
+package com.ourmenu.backend.domain.search.util;
+
+public class UrlUtil {
+
+    private UrlUtil() {
+
+    }
+
+    public static String parseStoreImgUrl(String imgUrl) {
+        if (imgUrl.startsWith("//")) {
+            return imgUrl.substring(2);
+        }
+        return imgUrl;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,3 +33,5 @@ spring.mail.properties.mail.smtp.connectiontimeout=5000
 spring.mail.properties.mail.smtp.timeout=5000
 spring.mail.properties.mail.smtp.writetimeout=5000
 mail.auth-code-expiration-millis=5 * 60 * 1000
+# KaKao API
+kakao.APIKey=${KAKAO_API_KEY}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,17 +10,17 @@ spring.datasource.url=jdbc:mysql://localhost:3306/ourmenu2
 spring.datasource.username=root
 spring.datasource.password=${MYSQL_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+#MongoDb
+spring.data.mongodb.uri=${MONGO_URL}
 # JPA Configuration
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
-
 #AWS S3
 spring.cloud.aws.credentials.bucket=${S3_BUCKET}
 spring.cloud.aws.credentials.accessKey=${S3_ACCESS_KEY}
 spring.cloud.aws.credentials.secretKey=${S3_SECRET_KEY}
-
 # Mail
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587


### PR DESCRIPTION
### ✏️ 작업 개요
- #21 

### ⛳ 작업 분류
- [x] 메뉴 검색
- [x] 메뉴 상세조회 (검색의 일부)
- [x] 검색 기록 조회

### 🔨 작업 상세 내용
1. 메뉴 검색 API 를 구현했습니다.
2. 지난번과 검색 흐름은 비슷한데 네이버 API -> 카카오 API으로 변경되었습니다
3. 캐시용 db(두번째 화살표)를 현재 mysql중인데 mysql vs mongoDB중 고민입니다.
   -  mysql에 한 이유는 최대한 비즈니스에 사용하는 부분은 rdb로 관리하고 싶었습니다.
   -  캐시용 db이지만 추가적인 비즈니스 로직이 생성될 가능성이 있어서 redis는 제외했어요
4. "검색어" 에 대해서 "검색어"를 가지고 있는 메뉴와 가게이름중 5개를 반환합니다.
   - 메뉴와 가게가 5개 이상일경우, 가게이름 -> 메뉴 가 우선시 해야된다고 생각합니다.
   - 예를들어 "고기"를 검색하면 "고기"이름을 가진 가게와 "고기"메뉴를 가진 가게중, **"고기" 이름을 가진 가게**가 선행되어햡니다
   - 위와 같은 선행 조건 검색 쿼리가 mongoDB에서 지원하지 않기 때문에 10개를 뽑은후 정렬 해서 5개만 반환하도록 구현하였습니다. (`searchStore` 메소드) 
5. 현재 메뉴가격을 String 으로 반환하고 있습니다.(Mongodb에도 String 으로 저장되어 있음) Converter 하는 방법도 생각해봤는데, Mongodb에 integer으로 저장되는게 맞다고 생각해서 추후에 데이터 전처리후 작업해야할 부분입니다
6. 메뉴 API와의 연결, 의존성은 menu 브랜치에서 진행하겠슴다.

<br>
<img src="https://github.com/user-attachments/assets/2bf34fc6-1f59-409b-afd5-684c83b7257d" width="500">
<br>


### 💡 생각해볼 문제
- 위에 작성한대로 3,4,5에 대해서 주로 리뷰해주시면 감사하겠습니다
