### PR TITLE
[Fix] 메뉴 검색 API

### DIFF
--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MenuFolderController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MenuFolderController.java
@@ -34,8 +34,7 @@ public class MenuFolderController {
     private final MenuFolderService menuFolderService;
 
     @GetMapping
-    public ApiResponse<List<GetMenuFolderResponse>> getMenuFolder(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ApiResponse<List<GetMenuFolderResponse>> getMenuFolder(@AuthenticationPrincipal CustomUserDetails userDetails) {
         List<GetMenuFolderResponse> response = menuFolderService.findAllMenuFolder(userDetails.getId());
         return ApiUtil.success(response);
     }

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MenuMenuFolderService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MenuMenuFolderService.java
@@ -1,0 +1,122 @@
+package com.ourmenu.backend.domain.menu.application;
+
+import com.ourmenu.backend.domain.menu.application.validator.MenuFolderValidator;
+import com.ourmenu.backend.domain.menu.application.validator.MenuValidator;
+import com.ourmenu.backend.domain.menu.dao.MenuFolderRepository;
+import com.ourmenu.backend.domain.menu.dao.MenuMenuFolderRepository;
+import com.ourmenu.backend.domain.menu.dao.MenuRepository;
+import com.ourmenu.backend.domain.menu.domain.Menu;
+import com.ourmenu.backend.domain.menu.domain.MenuFolder;
+import com.ourmenu.backend.domain.menu.domain.MenuMenuFolder;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MenuMenuFolderService {
+
+    private final MenuMenuFolderRepository menuMenuFolderRepository;
+    private final MenuRepository menuRepository;
+    private final MenuFolderRepository menuFolderRepository;
+    private final MenuFolderValidator menuFolderValidator;
+    private final MenuValidator menuValidator;
+
+    /**
+     * 메뉴 - 메뉴판 연관관계 설정(벌크) 내부적으로 saveMenuMenuFolder 호출
+     *
+     * @param menuFolderIds
+     * @param userId
+     * @param menu
+     * @return
+     */
+    @Transactional
+    public List<MenuMenuFolder> saveMenuMenuFolders(List<Long> menuFolderIds, Long userId, Menu menu) {
+        return menuFolderIds.stream().map(
+                menuFolderId -> saveMenuMenuFolder(userId, menuFolderId, menu)
+        ).toList();
+    }
+
+    /**
+     * 메뉴 - 메뉴판 연관관계 설정(벌크) 내부적으로 saveMenuMenuFolder 호출
+     *
+     * @param menuIds
+     * @param userId
+     * @param menuFolder
+     * @return
+     */
+    @Transactional
+    public List<MenuMenuFolder> saveMenuMenuFolders(List<Long> menuIds, Long userId, MenuFolder menuFolder) {
+        return menuIds.stream().map(
+                menuId -> saveMenuMenuFolder(userId, menuId, menuFolder)
+        ).toList();
+    }
+
+    @Transactional
+    public void deleteMenuMenuFolders(Menu menu) {
+        menuMenuFolderRepository.deleteAllByMenu(menu);
+    }
+
+    /**
+     * 연관관계를 재구성 (기존 삭제)
+     *
+     * @param userId
+     * @param menuFolderId
+     * @param menuIds      변경될 메뉴(size=0 이면 기존 모두 삭제)
+     */
+    @Transactional
+    public List<MenuMenuFolder> updateMenuMenuFolder(Long userId, Long menuFolderId, List<Long> menuIds) {
+        menuIds.forEach(menuId -> menuValidator.validateExistMenu(userId, menuId));
+        menuMenuFolderRepository.deleteByFolderId(menuFolderId);
+        MenuFolder menuFolder = menuFolderRepository.findById(menuFolderId).get();
+        return saveMenuMenuFolders(menuIds, userId, menuFolder);
+    }
+
+    /**
+     * 메뉴판에 해당하는 조인 컬럼 반환
+     *
+     * @param menuFolderId
+     * @return
+     */
+    @Transactional
+    public List<MenuMenuFolder> findAllByMenuFolderId(Long menuFolderId) {
+        return menuMenuFolderRepository.findAllByFolderId(menuFolderId);
+    }
+
+    /**
+     * 메뉴 - 메뉴판 연관관계 설정
+     *
+     * @param userId
+     * @param menuFolderId
+     * @param menu
+     * @return 저장된 메뉴-메뉴판 조인테이블 엔티티
+     */
+    private MenuMenuFolder saveMenuMenuFolder(Long userId, Long menuFolderId, Menu menu) {
+        menuFolderValidator.validateExistMenuFolder(userId, menuFolderId);
+        MenuMenuFolder menuMenuFolder = MenuMenuFolder.builder()
+                .menu(menu)
+                .folderId(menuFolderId)
+                .build();
+        return menuMenuFolderRepository.save(menuMenuFolder);
+    }
+
+    /**
+     * 메뉴 - 메뉴판 연관관계 설정
+     *
+     * @param userId
+     * @param menuId
+     * @param menuFolder
+     * @return 저장된 메뉴-메뉴판 조인테이블 엔티티
+     */
+    private MenuMenuFolder saveMenuMenuFolder(Long userId, Long menuId, MenuFolder menuFolder) {
+        menuValidator.validateExistMenu(userId, menuId);
+        Menu menu = menuRepository.findById(menuId).get();
+
+        MenuMenuFolder menuMenuFolder = MenuMenuFolder.builder()
+                .menu(menu)
+                .folderId(menuFolder.getId())
+                .build();
+        return menuMenuFolderRepository.save(menuMenuFolder);
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MenuService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MenuService.java
@@ -1,6 +1,5 @@
 package com.ourmenu.backend.domain.menu.application;
 
-import com.ourmenu.backend.domain.menu.dao.MenuMenuFolderRepository;
 import com.ourmenu.backend.domain.menu.dao.MenuRepository;
 import com.ourmenu.backend.domain.menu.domain.Menu;
 import com.ourmenu.backend.domain.menu.domain.MenuImg;
@@ -23,8 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MenuService {
 
     private final MenuRepository menuRepository;
-    private final MenuMenuFolderRepository menuMenuFolderRepository;
-    private final MenuFolderService menuFolderService;
+    private final MenuMenuFolderService menuMenuFolderService;
     private final MenuTagService menuTagService;
     private final StoreService storeService;
     private final MenuImgService menuImgService;
@@ -55,7 +53,8 @@ public class MenuService {
         Menu saveMenu = menuRepository.save(menu);
 
         //메뉴판 연관관계 생성
-        List<MenuMenuFolder> saveMenuMenuFolders = saveMenuMenuFolders(menuDto.getMenuFolderIds(), menuDto.getUserId(),
+        List<MenuMenuFolder> saveMenuMenuFolders = menuMenuFolderService.saveMenuMenuFolders(menuDto.getMenuFolderIds(),
+                menuDto.getUserId(),
                 saveMenu);
 
         //태그 연관관계 생성
@@ -76,41 +75,10 @@ public class MenuService {
     public void deleteMenu(Long userId, Long menuId) {
         Menu menu = findOne(userId, menuId);
         menuRepository.delete(menu);
-        deleteMenuMenuFolders(menu);
+        menuMenuFolderService.deleteMenuMenuFolders(menu);
         menuImgService.deleteMenuImgs(menuId);
         menuTagService.deleteMenuTag(menuId);
         storeService.deleteStore(menu.getStore());
-    }
-
-    /**
-     * 메뉴 - 메뉴판 연관관계 설정(벌크) 내부적으로 saveMenuMenuFolder 호출
-     *
-     * @param menuFolderIds
-     * @param userId
-     * @param menu
-     * @return
-     */
-    private List<MenuMenuFolder> saveMenuMenuFolders(List<Long> menuFolderIds, Long userId, Menu menu) {
-        return menuFolderIds.stream().map(
-                menuFolderId -> saveMenuMenuFolder(userId, menuFolderId, menu)
-        ).toList();
-    }
-
-    /**
-     * 메뉴 - 메뉴판 연관관계 설정
-     *
-     * @param userId
-     * @param menuFolderId
-     * @param menu
-     * @return 저장된 메뉴-메뉴판 조인테이블 엔티티
-     */
-    private MenuMenuFolder saveMenuMenuFolder(Long userId, Long menuFolderId, Menu menu) {
-        menuFolderService.validateExistMenuFolder(userId, menuFolderId);
-        MenuMenuFolder menuMenuFolder = MenuMenuFolder.builder()
-                .menu(menu)
-                .folderId(menuFolderId)
-                .build();
-        return menuMenuFolderRepository.save(menuMenuFolder);
     }
 
     private List<Tag> saveTags(List<Tag> tags, Long menuId) {
@@ -128,7 +96,4 @@ public class MenuService {
         return menu;
     }
 
-    private void deleteMenuMenuFolders(Menu menu) {
-        menuMenuFolderRepository.deleteAllByMenu(menu);
-    }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/validator/MenuFolderValidator.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/validator/MenuFolderValidator.java
@@ -1,0 +1,28 @@
+package com.ourmenu.backend.domain.menu.application.validator;
+
+import com.ourmenu.backend.domain.menu.dao.MenuFolderRepository;
+import com.ourmenu.backend.domain.menu.exception.ForbiddenMenuFolderException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MenuFolderValidator {
+
+    private final MenuFolderRepository menuFolderRepository;
+
+    /**
+     * 메뉴판 소유 여부 확인
+     *
+     * @param userId
+     * @param menuFolderId
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public void validateExistMenuFolder(Long userId, Long menuFolderId) {
+        if (!menuFolderRepository.existsByUserIdAndId(menuFolderId, userId)) {
+            throw new ForbiddenMenuFolderException();
+        }
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/validator/MenuValidator.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/validator/MenuValidator.java
@@ -1,0 +1,19 @@
+package com.ourmenu.backend.domain.menu.application.validator;
+
+import com.ourmenu.backend.domain.menu.dao.MenuRepository;
+import com.ourmenu.backend.domain.menu.exception.ForbiddenMenuException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MenuValidator {
+
+    private final MenuRepository menuRepository;
+
+    public void validateExistMenu(Long userId, Long menuId) {
+        if (!menuRepository.existsByUserIdAndId(userId, menuId)) {
+            throw new ForbiddenMenuException();
+        }
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuFolderRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuFolderRepository.java
@@ -30,4 +30,5 @@ public interface MenuFolderRepository extends JpaRepository<MenuFolder, Long> {
             "WHERE m.userId = :userId AND m.index BETWEEN :start AND :end")
     void decrementIndexes(@Param("userId") Long userId, @Param("start") int start, @Param("end") int end);
 
+    boolean existsByUserIdAndId(Long userId, Long id);
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuMenuFolderRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuMenuFolderRepository.java
@@ -2,9 +2,14 @@ package com.ourmenu.backend.domain.menu.dao;
 
 import com.ourmenu.backend.domain.menu.domain.Menu;
 import com.ourmenu.backend.domain.menu.domain.MenuMenuFolder;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MenuMenuFolderRepository extends JpaRepository<MenuMenuFolder, Long> {
 
+    List<MenuMenuFolder> findAllByFolderId(Long FolderId);
+
     void deleteAllByMenu(Menu menu);
+
+    void deleteByFolderId(Long folderId);
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     boolean existsByStore(Store store);
+
+    boolean existsByUserIdAndId(Long userId, Long id);
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuFolderResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuFolderResponse.java
@@ -22,7 +22,7 @@ public class GetMenuFolderResponse {
 
     public static GetMenuFolderResponse of(MenuFolder menuFolder, List<MenuMenuFolder> menuFolders) {
         List<Long> menuIds = menuFolders.stream()
-                .map(MenuMenuFolder::getFolderId)
+                .map(menuMenuFolder -> menuMenuFolder.getMenu().getId())
                 .toList();
         return GetMenuFolderResponse.builder()
                 .menuFolderId(menuFolder.getId())

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuFolderResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuFolderResponse.java
@@ -1,6 +1,7 @@
 package com.ourmenu.backend.domain.menu.dto;
 
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
+import com.ourmenu.backend.domain.menu.domain.MenuMenuFolder;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -19,12 +20,16 @@ public class GetMenuFolderResponse {
     private List<Long> menuIds;
     private int index;
 
-    public static GetMenuFolderResponse from(MenuFolder menuFolder) {
+    public static GetMenuFolderResponse of(MenuFolder menuFolder, List<MenuMenuFolder> menuFolders) {
+        List<Long> menuIds = menuFolders.stream()
+                .map(MenuMenuFolder::getFolderId)
+                .toList();
         return GetMenuFolderResponse.builder()
                 .menuFolderId(menuFolder.getId())
                 .menuFolderTitle(menuFolder.getTitle())
                 .menuFolderUrl(menuFolder.getImgUrl())
                 .menuFolderIcon(menuFolder.getIcon())
+                .menuIds(menuIds)
                 .index(menuFolder.getIndex())
                 .build();
     }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuFolderResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuFolderResponse.java
@@ -19,12 +19,13 @@ public class SaveMenuFolderResponse {
     private List<Long> menuIds;
     private int index;
 
-    public static SaveMenuFolderResponse from(MenuFolder menuFolder) {
+    public static SaveMenuFolderResponse of(MenuFolder menuFolder, List<Long> menuIds) {
         return SaveMenuFolderResponse.builder()
                 .menuFolderId(menuFolder.getId())
                 .menuFolderTitle(menuFolder.getTitle())
                 .menuFolderUrl(menuFolder.getImgUrl())
                 .menuFolderIcon(menuFolder.getIcon())
+                .menuIds(menuIds)
                 .index(menuFolder.getIndex())
                 .build();
     }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/UpdateMenuFolderResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/UpdateMenuFolderResponse.java
@@ -22,7 +22,7 @@ public class UpdateMenuFolderResponse {
 
     public static UpdateMenuFolderResponse of(MenuFolder menuFolder, List<MenuMenuFolder> menuMenuFolders) {
         List<Long> menuId = menuMenuFolders.stream()
-                .map(menuMenuFolder -> menuMenuFolder.getFolderId())
+                .map(menuMenuFolder -> menuMenuFolder.getMenu().getId())
                 .toList();
         return UpdateMenuFolderResponse.builder()
                 .menuFolderId(menuFolder.getId())

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/UpdateMenuFolderResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/UpdateMenuFolderResponse.java
@@ -1,6 +1,7 @@
 package com.ourmenu.backend.domain.menu.dto;
 
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
+import com.ourmenu.backend.domain.menu.domain.MenuMenuFolder;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -19,12 +20,16 @@ public class UpdateMenuFolderResponse {
     private List<Long> menuIds;
     private int index;
 
-    public static UpdateMenuFolderResponse from(MenuFolder menuFolder) {
+    public static UpdateMenuFolderResponse of(MenuFolder menuFolder, List<MenuMenuFolder> menuMenuFolders) {
+        List<Long> menuId = menuMenuFolders.stream()
+                .map(menuMenuFolder -> menuMenuFolder.getFolderId())
+                .toList();
         return UpdateMenuFolderResponse.builder()
                 .menuFolderId(menuFolder.getId())
                 .menuFolderTitle(menuFolder.getTitle())
                 .menuFolderUrl(menuFolder.getImgUrl())
                 .menuFolderIcon(menuFolder.getIcon())
+                .menuIds(menuId)
                 .index(menuFolder.getIndex())
                 .build();
     }


### PR DESCRIPTION
### ✏️ 작업 개요
- #21 

### ⛳ 작업 분류
- [x] 메뉴판 저장 메뉴 폴더 저장 연동
- [x] 메뉴판 수정 메뉴폴더 연동
- [x] 메뉴판 조회 메뉴폴더 연동

### 🔨 작업 상세 내용
1. 메뉴API 이전에 메뉴판 API에 대해서 추가되어야할 로직을 추가했습니다.
2. 메뉴판 저장 수정 조회시 메뉴판 + 메뉴 Id를 반환하도록 변경되었습니다
3. 아래 엔드포인트은 20일 회의 이전에 수정되지 않습니다
    - GET api/menu-folders
    - POST api/menu-folders
    - PATCH api/menu-folders/{menuFolderId}
    - PATCH api/menu-folders/{menuFolderId}/index
    - DELETE api/menu-folders/{menuFolderId} 

### 💡 생각해볼 문제
- menuMenuFolderService를 따로 분리하였습니다
   - 메뉴 -> 메뉴판, 메뉴판 -> 메뉴 방향으로 수정이 가능한 상황이라 순환 참조 문제가 발생해서 따로 클래스를 분리했습니다.
- 현재 연관관계 엔티티로 사용하지 않고, 외래키로 약속하고 사용하고 있기 때문에, 직접 검증 코드를 필요로 했습니다.
   - 유효성 검증에서도 마찬가지로 순환 참조 문제가 발생하기 때문에 클래스를 분리하였습니다.
   - validator에서는 repository를 사용하되 변경이 일어나선 안됩니다.
- 이렇다 보니 여러 service에서 repository를 공유해서 사용하고 있습니다.
   - 예를들면 validate는 find함수를 호출하는 것으로도 해결할 수 있습니다.
   - 그러나 find함수를 호출하려면 순환 참조가 발생합니다. 
   - 해결책은 찾지 못해서 불가피하다고 생각하고 있습니다.
