### PR TITLE
[FIX} 메뉴 저장시 storeId 사용하도록 변경

### DIFF
--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MenuController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MenuController.java
@@ -4,6 +4,8 @@ import com.ourmenu.backend.domain.menu.application.MenuService;
 import com.ourmenu.backend.domain.menu.dto.MenuDto;
 import com.ourmenu.backend.domain.menu.dto.SaveMenuRequest;
 import com.ourmenu.backend.domain.menu.dto.SaveMenuResponse;
+import com.ourmenu.backend.domain.search.application.SearchService;
+import com.ourmenu.backend.domain.search.dto.SimpleSearchDto;
 import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
 import com.ourmenu.backend.global.response.ApiResponse;
 import com.ourmenu.backend.global.response.util.ApiUtil;
@@ -25,12 +27,14 @@ import org.springframework.web.multipart.MultipartFile;
 public class MenuController {
 
     private final MenuService menuService;
+    private final SearchService searchService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<SaveMenuResponse> saveMenu(@RequestPart("data") SaveMenuRequest request,
                                                   @RequestPart(value = "menuFolderImgs", required = false) List<MultipartFile> menuFolderImgs,
                                                   @AuthenticationPrincipal CustomUserDetails userDetails) {
-        MenuDto menuDto = MenuDto.of(request, menuFolderImgs, userDetails);
+        SimpleSearchDto simpleSearchDto = searchService.getSearchDto(request.isCrawled(), request.getStoreId());
+        MenuDto menuDto = MenuDto.of(request, menuFolderImgs, userDetails, simpleSearchDto);
         SaveMenuResponse response = menuService.saveMenu(menuDto);
         return ApiUtil.success(response);
     }
@@ -41,5 +45,4 @@ public class MenuController {
         menuService.deleteMenu(userDetails.getId(), menuId);
         return ApiUtil.successOnly();
     }
-
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuDto.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
+import com.ourmenu.backend.domain.search.dto.SimpleSearchDto;
 import com.ourmenu.backend.domain.tag.domain.Tag;
 import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
 import java.util.List;
@@ -21,6 +22,7 @@ public class MenuDto {
     private String menuMemoContent;
     private int menuPin;
     private List<Long> menuFolderIds;
+    private String storeId;
     private boolean isCrawled;
     private List<Tag> tags;
     private String storeTitle;
@@ -30,7 +32,7 @@ public class MenuDto {
     private Long userId;
 
     public static MenuDto of(SaveMenuRequest request, List<MultipartFile> menuFolderImgs,
-                             CustomUserDetails userDetails) {
+                             CustomUserDetails userDetails, SimpleSearchDto simpleSearchDto) {
         return MenuDto.builder()
                 .menuImgs(menuFolderImgs)
                 .menuTitle(request.getMenuTitle())
@@ -41,10 +43,10 @@ public class MenuDto {
                 .menuFolderIds(request.getMenuFolderIds())
                 .isCrawled(request.isCrawled())
                 .tags(request.getTags())
-                .storeTitle(request.getStoreTitle())
-                .storeAddress(request.getStoreAddress())
-                .mapX(request.getMapX())
-                .mapY(request.getMapY())
+                .storeTitle(simpleSearchDto.getStoreTitle())
+                .storeAddress(simpleSearchDto.getStoreAddress())
+                .mapX(simpleSearchDto.getMapX())
+                .mapY(simpleSearchDto.getMapY())
                 .userId(userDetails.getId())
                 .build();
     }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuRequest.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ourmenu.backend.domain.tag.domain.Tag;
 import java.util.List;
 import lombok.Getter;
@@ -15,10 +16,8 @@ public class SaveMenuRequest {
     private String menuMemoTitle;
     private String menuMemoContent;
     private List<Long> menuFolderIds;
+    private String storeId;
+    @JsonProperty("isCrawled")
     private boolean isCrawled;
     private List<Tag> tags;
-    private String storeTitle;
-    private String storeAddress;
-    private Double mapX;
-    private Double mapY;
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/application/SearchService.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/application/SearchService.java
@@ -9,6 +9,7 @@ import com.ourmenu.backend.domain.search.domain.SearchableStore;
 import com.ourmenu.backend.domain.search.dto.GetSearchHistoryResponse;
 import com.ourmenu.backend.domain.search.dto.GetStoreResponse;
 import com.ourmenu.backend.domain.search.dto.SearchStoreResponse;
+import com.ourmenu.backend.domain.search.dto.SimpleSearchDto;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -70,6 +71,24 @@ public class SearchService {
         GetStoreResponse response = GetStoreResponse.from(cacheEntityByStoreId);
         saveSearchHistory(userId, response);
         return response;
+    }
+
+    /**
+     * 단순 가게 정보 Dto를 반환한다.
+     *
+     * @param isCrawled
+     * @param storeId
+     * @return
+     */
+    @Transactional
+    public SimpleSearchDto getSearchDto(boolean isCrawled, String storeId) {
+        if (isCrawled) {
+            SearchableStore searchableStore = findByStoreId(storeId);
+            return SimpleSearchDto.of(searchableStore, isCrawled);
+
+        }
+        NotFoundStore notFoundStore = findCacheEntityByStoreId(storeId);
+        return SimpleSearchDto.of(notFoundStore, isCrawled);
     }
 
     /**

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/SearchableStore.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/SearchableStore.java
@@ -22,6 +22,8 @@ public class SearchableStore {
     @Field(name = "menus")
     private List<StoreMenu> storeMenus;
     private String storeId;
+    @Field(name = "mapx")
     private Double mapX;
+    @Field(name = "mapy")
     private Double mapY;
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/dto/SimpleSearchDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dto/SimpleSearchDto.java
@@ -1,0 +1,43 @@
+package com.ourmenu.backend.domain.search.dto;
+
+import com.ourmenu.backend.domain.search.domain.NotFoundStore;
+import com.ourmenu.backend.domain.search.domain.SearchableStore;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder
+public class SimpleSearchDto {
+
+    private String storeId;
+    private boolean isCrawled;
+    private String storeTitle;
+    private String storeAddress;
+    private Double mapX;
+    private Double mapY;
+
+    public static SimpleSearchDto of(SearchableStore searchableStore, boolean isCrawled) {
+        return SimpleSearchDto.builder()
+                .storeId(searchableStore.getStoreId())
+                .isCrawled(isCrawled)
+                .storeTitle(searchableStore.getTitle())
+                .storeAddress(searchableStore.getAddress())
+                .mapX(searchableStore.getMapX())
+                .mapY(searchableStore.getMapY())
+                .build();
+    }
+
+    public static SimpleSearchDto of(NotFoundStore notFoundStore, boolean isCrawled) {
+        return SimpleSearchDto.builder()
+                .storeId(notFoundStore.getStoreId())
+                .isCrawled(isCrawled)
+                .storeTitle(notFoundStore.getTitle())
+                .storeAddress(notFoundStore.getAddress())
+                .mapX(notFoundStore.getMapX())
+                .mapY(notFoundStore.getMapY())
+                .build();
+    }
+}


### PR DESCRIPTION

### ✏️ 작업 개요
- #27 

### ⛳ 작업 분류
- [x] 검색 메뉴 수정
- [x] 버그 수정

### 🔨 작업 상세 내용
1. 메뉴 저장시 가게 정보를 storeId를 통해 저장하도록 변경하였습니다.
2. 엔티티와 몽고디비 에서 서로 다른 네이밍을 사용하고 있어서 수정하였습니다

### 💡 생각해볼 문제
- 현재 몽고디비에 mapX, mapY에 더미값을 넣어놨습니다.
