### PR TITLE
[Feat] Map API 구현

### DIFF
--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
@@ -55,7 +55,7 @@ public class MapController {
         return ApiUtil.success(response);
     }
 
-    @GetMapping("/{menuId}/maps")
+    @GetMapping("/maps/{menuId}/search")
     public ApiResponse<MenuInfoOnMapDto> findMenuInfoByMenuId(@PathVariable Long menuId, @AuthenticationPrincipal CustomUserDetails userDetails){
         MenuInfoOnMapDto response = mapService.findMenuByMenuIdOnMap(menuId, userDetails.getId());
         return ApiUtil.success(response);

--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
@@ -33,4 +33,15 @@ public class MapController {
         return ApiUtil.success(response);
     }
 
+    /**
+     * 지도 상세 조회 API
+     * @param mapId
+     * @param userDetails
+     * @return
+     */
+    @GetMapping("/{mapId}")
+    public ApiResponse<List<MenuInfoOnMapDto>> findMenuInfoOnMap(@PathVariable Long mapId, @AuthenticationPrincipal CustomUserDetails userDetails){
+        List<MenuInfoOnMapDto> response = mapService.findMenuOnMap(mapId, userDetails.getId());
+        return ApiUtil.success(response);
+    }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
@@ -38,7 +38,7 @@ public class MapController {
      * @return
      */
     @GetMapping("/{mapId}")
-    public ApiResponse<List<MenuInfoOnMapDto>> findMenuInfoOnMap(@PathVariable Long mapId, @AuthenticationPrincipal CustomUserDetails userDetails){
+    public ApiResponse<List<MenuInfoOnMapDto>> findMenuInfoByMapId(@PathVariable Long mapId, @AuthenticationPrincipal CustomUserDetails userDetails){
         List<MenuInfoOnMapDto> response = mapService.findMenuOnMap(mapId, userDetails.getId());
         return ApiUtil.success(response);
     }
@@ -55,5 +55,15 @@ public class MapController {
         return ApiUtil.success(response);
     }
 
+    @GetMapping("/{menuId}")
+    public ApiResponse<MenuInfoOnMapDto> findMenuInfoByMenuId(@PathVariable Long menuId, @AuthenticationPrincipal CustomUserDetails userDetails){
+        MenuInfoOnMapDto response = mapService.findMenuByMenuIdOnMap(menuId, userDetails.getId());
+        return ApiUtil.success(response);
+    }
 
+    @GetMapping("/{storeId}")
+    public ApiResponse<List<MenuInfoOnMapDto>> findMenuInfoByStoreId(@PathVariable Long storeId, @AuthenticationPrincipal CustomUserDetails userDetails){
+        List<MenuInfoOnMapDto> response = mapService.findMenuByStoreIdOnMap(storeId, userDetails.getId());
+        return ApiUtil.success(response);
+    }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
@@ -55,6 +55,12 @@ public class MapController {
         return ApiUtil.success(response);
     }
 
+    /**
+     * 지도 화면 MenuID 값으로 메뉴 상세 조회
+     * @param menuId
+     * @param userDetails
+     * @return
+     */
     @GetMapping("/maps/{menuId}/search")
     public ApiResponse<MenuInfoOnMapDto> findMenuInfoByMenuId(@PathVariable Long menuId, @AuthenticationPrincipal CustomUserDetails userDetails){
         MenuInfoOnMapDto response = mapService.findMenuByMenuIdOnMap(menuId, userDetails.getId());
@@ -67,6 +73,11 @@ public class MapController {
 //        return ApiUtil.success(response);
 //    }
 
+    /**
+     * 지도 화면 유저 검색 기록 조회
+     * @param userDetails
+     * @return
+     */
     @GetMapping("/maps/search-history")
     public ApiResponse<List<MapSearchDto>> findSearchHistoryOnMap(@AuthenticationPrincipal CustomUserDetails userDetails){
         List<MapSearchDto> response = mapService.findSearchHistoryOnMap(userDetails.getId());

--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/users/menus/maps")
+@RequestMapping("/api/users/menus")
 public class MapController {
 
     private final MapService mapService;
@@ -25,7 +25,7 @@ public class MapController {
      * @param userDetails
      * @return
      */
-    @GetMapping("")
+    @GetMapping("/maps")
     public ApiResponse<List<MenuOnMapDto>> findMenusOnMap(@AuthenticationPrincipal CustomUserDetails userDetails) {
         List<MenuOnMapDto> response = mapService.findMenusOnMap(userDetails.getId());
         return ApiUtil.success(response);
@@ -37,7 +37,7 @@ public class MapController {
      * @param userDetails
      * @return
      */
-    @GetMapping("/{mapId}")
+    @GetMapping("/{mapId}/maps")
     public ApiResponse<List<MenuInfoOnMapDto>> findMenuInfoByMapId(@PathVariable Long mapId, @AuthenticationPrincipal CustomUserDetails userDetails){
         List<MenuInfoOnMapDto> response = mapService.findMenuOnMap(mapId, userDetails.getId());
         return ApiUtil.success(response);
@@ -49,13 +49,13 @@ public class MapController {
      * @param userDetails
      * @return
      */
-    @GetMapping("/search")
+    @GetMapping("/maps/search")
     public ApiResponse<List<MapSearchDto>> findSearchOnMap(@RequestParam String title, @AuthenticationPrincipal CustomUserDetails userDetails){
         List<MapSearchDto> response = mapService.findSearchResultOnMap(title, userDetails.getId());
         return ApiUtil.success(response);
     }
 
-    @GetMapping("/{menuId}")
+    @GetMapping("/{menuId}/maps")
     public ApiResponse<MenuInfoOnMapDto> findMenuInfoByMenuId(@PathVariable Long menuId, @AuthenticationPrincipal CustomUserDetails userDetails){
         MenuInfoOnMapDto response = mapService.findMenuByMenuIdOnMap(menuId, userDetails.getId());
         return ApiUtil.success(response);
@@ -67,7 +67,7 @@ public class MapController {
 //        return ApiUtil.success(response);
 //    }
 
-    @GetMapping("/search-history")
+    @GetMapping("/maps/search-history")
     public ApiResponse<List<MapSearchDto>> findSearchHistoryOnMap(@AuthenticationPrincipal CustomUserDetails userDetails){
         List<MapSearchDto> response = mapService.findSearchHistoryOnMap(userDetails.getId());
         return ApiUtil.success(response);

--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
@@ -66,4 +66,10 @@ public class MapController {
         List<MenuInfoOnMapDto> response = mapService.findMenuByStoreIdOnMap(storeId, userDetails.getId());
         return ApiUtil.success(response);
     }
+
+    @GetMapping("/search-history")
+    public ApiResponse<List<MapSearchDto>> findSearchHistoryOnMap(@AuthenticationPrincipal CustomUserDetails userDetails){
+        List<MapSearchDto> response = mapService.findSearchHistoryOnMap(userDetails.getId());
+        return ApiUtil.success(response);
+    }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
@@ -2,6 +2,7 @@ package com.ourmenu.backend.domain.menu.api;
 
 import com.ourmenu.backend.domain.menu.application.MapService;
 import com.ourmenu.backend.domain.menu.dto.MapSearchDto;
+import com.ourmenu.backend.domain.menu.dto.MapSearchHistoryDto;
 import com.ourmenu.backend.domain.menu.dto.MenuInfoOnMapDto;
 import com.ourmenu.backend.domain.menu.dto.MenuOnMapDto;
 import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
@@ -79,8 +80,8 @@ public class MapController {
      * @return
      */
     @GetMapping("/maps/search-history")
-    public ApiResponse<List<MapSearchDto>> findSearchHistoryOnMap(@AuthenticationPrincipal CustomUserDetails userDetails){
-        List<MapSearchDto> response = mapService.findSearchHistoryOnMap(userDetails.getId());
+    public ApiResponse<List<MapSearchHistoryDto>> findSearchHistoryOnMap(@AuthenticationPrincipal CustomUserDetails userDetails){
+        List<MapSearchHistoryDto> response = mapService.findSearchHistoryOnMap(userDetails.getId());
         return ApiUtil.success(response);
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
@@ -1,0 +1,36 @@
+package com.ourmenu.backend.domain.menu.api;
+
+import com.ourmenu.backend.domain.menu.application.MapService;
+import com.ourmenu.backend.domain.menu.dto.MenuInfoOnMapDto;
+import com.ourmenu.backend.domain.menu.dto.MenuOnMapDto;
+import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
+import com.ourmenu.backend.global.response.ApiResponse;
+import com.ourmenu.backend.global.response.util.ApiUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users/menus/maps")
+public class MapController {
+
+    private final MapService mapService;
+
+    /**
+     * 지도 조회 API (핀)
+     * @param userDetails
+     * @return
+     */
+    @GetMapping("")
+    public ApiResponse<List<MenuOnMapDto>> findMenusOnMap(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<MenuOnMapDto> response = mapService.findMenusOnMap(userDetails.getId());
+        return ApiUtil.success(response);
+    }
+
+}

--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
@@ -1,6 +1,7 @@
 package com.ourmenu.backend.domain.menu.api;
 
 import com.ourmenu.backend.domain.menu.application.MapService;
+import com.ourmenu.backend.domain.menu.dto.MapSearchDto;
 import com.ourmenu.backend.domain.menu.dto.MenuInfoOnMapDto;
 import com.ourmenu.backend.domain.menu.dto.MenuOnMapDto;
 import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
@@ -8,10 +9,7 @@ import com.ourmenu.backend.global.response.ApiResponse;
 import com.ourmenu.backend.global.response.util.ApiUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -44,4 +42,18 @@ public class MapController {
         List<MenuInfoOnMapDto> response = mapService.findMenuOnMap(mapId, userDetails.getId());
         return ApiUtil.success(response);
     }
+
+    /**
+     * 지도 화면 검색 API
+     * @param title
+     * @param userDetails
+     * @return
+     */
+    @GetMapping("/search")
+    public ApiResponse<List<MapSearchDto>> findSearchOnMap(@RequestParam String title, @AuthenticationPrincipal CustomUserDetails userDetails){
+        List<MapSearchDto> response = mapService.findSearchResultOnMap(title, userDetails.getId());
+        return ApiUtil.success(response);
+    }
+
+
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
@@ -61,11 +61,11 @@ public class MapController {
         return ApiUtil.success(response);
     }
 
-    @GetMapping("/{storeId}")
-    public ApiResponse<List<MenuInfoOnMapDto>> findMenuInfoByStoreId(@PathVariable Long storeId, @AuthenticationPrincipal CustomUserDetails userDetails){
-        List<MenuInfoOnMapDto> response = mapService.findMenuByStoreIdOnMap(storeId, userDetails.getId());
-        return ApiUtil.success(response);
-    }
+//    @GetMapping("/{storeId}")
+//    public ApiResponse<List<MenuInfoOnMapDto>> findMenuInfoByStoreId(@PathVariable Long storeId, @AuthenticationPrincipal CustomUserDetails userDetails){
+//        List<MenuInfoOnMapDto> response = mapService.findMenuByStoreIdOnMap(storeId, userDetails.getId());
+//        return ApiUtil.success(response);
+//    }
 
     @GetMapping("/search-history")
     public ApiResponse<List<MapSearchDto>> findSearchHistoryOnMap(@AuthenticationPrincipal CustomUserDetails userDetails){

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
@@ -61,11 +61,9 @@ public class MapService {
                 .filter(menu -> menu.getStore().getMap() != null)
                 .collect(Collectors.groupingBy(menu -> menu.getStore().getMap()));
 
-        List<MenuOnMapDto> response = menuMaps.entrySet().stream()
+        return menuMaps.entrySet().stream()
                 .map(entry -> MenuOnMapDto.from(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
-
-        return response;
     }
 
     public List<MenuInfoOnMapDto> findMenuOnMap(Long mapId, Long userId) {
@@ -74,17 +72,17 @@ public class MapService {
 
         List<Store> stores = map.getStores();
         List<Menu> menus = new ArrayList<>();
-        List<MenuInfoOnMapDto> response = new ArrayList<>();
+        List<MenuInfoOnMapDto> menuInfoOnMapDtos = new ArrayList<>();
 
         for (Store store : stores) {
             menus = menuRepository.findMenusByStoreIdAndUserId(store.getId(), userId);
         }
 
         for (Menu menu : menus) {
-            response.add(getMenuInfo(menu));
+            menuInfoOnMapDtos.add(getMenuInfo(menu));
         }
 
-        return response;
+        return menuInfoOnMapDtos;
     }
 
     public List<MapSearchDto> findSearchResultOnMap(String title, Long userId) {
@@ -92,7 +90,7 @@ public class MapService {
                 .orElseThrow(UserNotFoundException::new);
 
         List<Menu> menus = menuRepository.findMenusByUserId(userId);
-        List<MapSearchDto> response = menus.stream()
+        List<MapSearchDto> mapSearchDtos = menus.stream()
                 .filter(m -> m.getStore().getTitle().contains(title)
                         || m.getTitle().contains(title))
                 .map(MapSearchDto::from)
@@ -106,7 +104,7 @@ public class MapService {
 
         ownedMenuSearchRepository.save(ownedMenuSearch);
 
-        return response;
+        return mapSearchDtos;
     }
 
     public List<MapSearchDto> findSearchHistoryOnMap(Long userId) {
@@ -115,30 +113,27 @@ public class MapService {
         Page<OwnedMenuSearch> searchHistoryPage = ownedMenuSearchRepository
                 .findByUserIdOrderBySearchAtDesc(userId, pageable);
 
-        List<MapSearchDto> response = searchHistoryPage.stream()
+        return searchHistoryPage.stream()
                 .map(MapSearchDto::from)
                 .collect(Collectors.toList());
-
-        return response;
     }
 
     public MenuInfoOnMapDto findMenuByMenuIdOnMap(Long menuId, Long userId) {
         Menu menu = menuRepository.findByIdAndUserId(menuId, userId);
 
-        MenuInfoOnMapDto response = getInfo(menu);
-        return response;
+        return getMenuInfo(menu);
     }
 
 
     public List<MenuInfoOnMapDto> findMenuByStoreIdOnMap(Long storeId, Long userId) {
         List<Menu> menus = menuRepository.findByUserIdAndStoreId(userId, storeId);
-        List<MenuInfoOnMapDto> response = new ArrayList<>();
+        List<MenuInfoOnMapDto> menuInfoOnMapDtos = new ArrayList<>();
 
         for (Menu menu : menus) {
-            response.add(getMenuInfo(menu));
+            menuInfoOnMapDtos.add(getMenuInfo(menu));
         }
 
-        return response;
+        return menuInfoOnMapDtos;
     }
 
     private MenuInfoOnMapDto getMenuInfo(Menu menu) {
@@ -152,7 +147,6 @@ public class MapService {
 
         MenuFolderInfoOnMapDto menuFolderInfo = MenuFolderInfoOnMapDto.of(latestMenuFolder, menuFolders.size());
 
-        MenuInfoOnMapDto response = MenuInfoOnMapDto.of(menu, menuTags, menuImgs, menuFolderInfo);
-        return response;
+        return MenuInfoOnMapDto.of(menu, menuTags, menuImgs, menuFolderInfo);
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
@@ -60,4 +60,31 @@ public class MapService {
         return response;
     }
 
+    public List<MenuInfoOnMapDto> findMenuOnMap(Long mapId, Long userId) {
+        Map map = mapRepository.findMapById(mapId)
+                .orElseThrow(RuntimeException::new);    //예외처리 수정 필요
+
+        List<Store> stores = map.getStores();
+        List<Menu> menus = new ArrayList<>();
+        List<MenuInfoOnMapDto> response = new ArrayList<>();
+
+        for (Store store : stores) {
+            menus = menuRepository.findMenusByStoreIdAndUserId(store.getId(), userId);
+        }
+
+        for (Menu menu : menus) {
+            List<MenuTag> menuTags = menuTagRepository.findMenuTagsByMenuId(menu.getId());
+            List<MenuImg> menuImgs = menuImgRepository.findAllByMenuId(menu.getId());
+            List<MenuFolder> menuFolders = menuFolderRepository.findMenuFoldersByMenuId(menu.getId());
+
+            MenuFolder latestMenuFolder = menuFolders.stream()
+                    .max(Comparator.comparing(MenuFolder::getCreatedAt)) // createdAt으로 정렬
+                    .orElseThrow(RuntimeException::new);        //예외처리 수정 필요
+
+            MenuFolderInfoOnMapDto menuFolderInfo = MenuFolderInfoOnMapDto.of(latestMenuFolder, menuFolders.size());
+            response.add(MenuInfoOnMapDto.of(menu, menuTags, menuImgs, menuFolderInfo));
+        }
+
+        return response;
+    }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
@@ -4,10 +4,7 @@ import com.ourmenu.backend.domain.menu.dao.MenuFolderRepository;
 import com.ourmenu.backend.domain.menu.dao.MenuImgRepository;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
 import com.ourmenu.backend.domain.menu.domain.MenuImg;
-import com.ourmenu.backend.domain.menu.dto.MapSearchDto;
-import com.ourmenu.backend.domain.menu.dto.MenuFolderInfoOnMapDto;
-import com.ourmenu.backend.domain.menu.dto.MenuInfoOnMapDto;
-import com.ourmenu.backend.domain.menu.dto.MenuOnMapDto;
+import com.ourmenu.backend.domain.menu.dto.*;
 import com.ourmenu.backend.domain.menu.dao.MenuRepository;
 import com.ourmenu.backend.domain.menu.domain.Menu;
 import com.ourmenu.backend.domain.search.dao.OwnedMenuSearchRepository;
@@ -27,8 +24,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -99,17 +96,18 @@ public class MapService {
         return mapSearchDtos;
     }
 
-    public List<MapSearchDto> findSearchHistoryOnMap(Long userId) {
+    public List<MapSearchHistoryDto> findSearchHistoryOnMap(Long userId) {
         Pageable pageable = PageRequest.of(0, 10);
 
         Page<OwnedMenuSearch> searchHistoryPage = ownedMenuSearchRepository
-                .findByUserIdOrderBySearchAtDesc(userId, pageable);
+                .findByUserIdOrderByModifiedAtDesc(userId, pageable);
 
         return searchHistoryPage.stream()
-                .map(MapSearchDto::from)
+                .map(MapSearchHistoryDto::from)
                 .collect(Collectors.toList());
     }
 
+    @Transactional
     public MenuInfoOnMapDto findMenuByMenuIdOnMap(Long menuId, Long userId) {
         Menu menu = menuRepository.findByIdAndUserId(menuId, userId);
 
@@ -118,7 +116,6 @@ public class MapService {
                 .storeTitle(menu.getStore().getTitle())
                 .storeAddress(menu.getStore().getAddress())
                 .userId(userId)
-                .searchAt(LocalDateTime.now())
                 .build();
 
         ownedMenuSearchRepository.save(ownedMenuSearch);

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
@@ -4,6 +4,7 @@ import com.ourmenu.backend.domain.menu.dao.MenuFolderRepository;
 import com.ourmenu.backend.domain.menu.dao.MenuImgRepository;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
 import com.ourmenu.backend.domain.menu.domain.MenuImg;
+import com.ourmenu.backend.domain.menu.dto.MapSearchDto;
 import com.ourmenu.backend.domain.menu.dto.MenuFolderInfoOnMapDto;
 import com.ourmenu.backend.domain.menu.dto.MenuInfoOnMapDto;
 import com.ourmenu.backend.domain.menu.dto.MenuOnMapDto;
@@ -16,6 +17,7 @@ import com.ourmenu.backend.domain.store.domain.Store;
 import com.ourmenu.backend.domain.tag.dao.MenuTagRepository;
 import com.ourmenu.backend.domain.tag.domain.MenuTag;
 import com.ourmenu.backend.domain.user.dao.UserRepository;
+import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
 import com.ourmenu.backend.domain.user.domain.User;
 import com.ourmenu.backend.domain.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -84,6 +87,20 @@ public class MapService {
             MenuFolderInfoOnMapDto menuFolderInfo = MenuFolderInfoOnMapDto.of(latestMenuFolder, menuFolders.size());
             response.add(MenuInfoOnMapDto.of(menu, menuTags, menuImgs, menuFolderInfo));
         }
+
+        return response;
+    }
+
+    public List<MapSearchDto> findSearchResultOnMap(String title, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        List<Menu> menus = menuRepository.findMenusByUserId(userId);
+        List<MapSearchDto> response = menus.stream()
+                .filter(m -> m.getStore().getTitle().contains(title)
+                        || m.getTitle().contains(title))
+                .map(MapSearchDto::from)
+                .toList();
 
         return response;
     }

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
@@ -1,0 +1,63 @@
+package com.ourmenu.backend.domain.menu.application;
+
+import com.ourmenu.backend.domain.menu.dao.MenuFolderRepository;
+import com.ourmenu.backend.domain.menu.dao.MenuImgRepository;
+import com.ourmenu.backend.domain.menu.domain.MenuFolder;
+import com.ourmenu.backend.domain.menu.domain.MenuImg;
+import com.ourmenu.backend.domain.menu.dto.MenuFolderInfoOnMapDto;
+import com.ourmenu.backend.domain.menu.dto.MenuInfoOnMapDto;
+import com.ourmenu.backend.domain.menu.dto.MenuOnMapDto;
+import com.ourmenu.backend.domain.menu.dao.MenuRepository;
+import com.ourmenu.backend.domain.menu.domain.Menu;
+import com.ourmenu.backend.domain.store.dao.MapRepository;
+import com.ourmenu.backend.domain.store.dao.StoreRepository;
+import com.ourmenu.backend.domain.store.domain.Map;
+import com.ourmenu.backend.domain.store.domain.Store;
+import com.ourmenu.backend.domain.tag.dao.MenuTagRepository;
+import com.ourmenu.backend.domain.tag.domain.MenuTag;
+import com.ourmenu.backend.domain.user.dao.UserRepository;
+import com.ourmenu.backend.domain.user.domain.User;
+import com.ourmenu.backend.domain.user.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MapService {
+
+    private final MenuRepository menuRepository;
+    private final UserRepository userRepository;
+    private final StoreRepository storeRepository;
+    private final MapRepository mapRepository;
+    private final MenuTagRepository menuTagRepository;
+    private final MenuImgRepository menuImgRepository;
+    private final MenuFolderRepository menuFolderRepository;
+
+    /**
+     * 유저의 Menu를 가져와 mapId가 같은 Menu들을 Map 형식으로 그룹핑 후 response 반환
+     * @param userId
+     * @return
+     */
+    public List<MenuOnMapDto> findMenusOnMap(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        List<Menu> menus = menuRepository.findMenusByUserId(userId);
+        
+        java.util.Map<Map, List<Menu>> menuMaps = menus.stream()
+                .filter(menu -> menu.getStore().getMap() != null)
+                .collect(Collectors.groupingBy(menu -> menu.getStore().getMap()));
+
+        List<MenuOnMapDto> response = menuMaps.entrySet().stream()
+                .map(entry -> MenuOnMapDto.from(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+
+        return response;
+    }
+
+}

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
@@ -87,13 +87,12 @@ public class MapService {
                 .orElseThrow(UserNotFoundException::new);
 
         List<Menu> menus = menuRepository.findMenusByUserId(userId);
-        List<MapSearchDto> mapSearchDtos = menus.stream()
+
+        return menus.stream()
                 .filter(m -> m.getStore().getTitle().contains(title)
                         || m.getTitle().contains(title))
                 .map(MapSearchDto::from)
                 .toList();
-
-        return mapSearchDtos;
     }
 
     public List<MapSearchHistoryDto> findSearchHistoryOnMap(Long userId) {
@@ -110,19 +109,9 @@ public class MapService {
     @Transactional
     public MenuInfoOnMapDto findMenuByMenuIdOnMap(Long menuId, Long userId) {
         Menu menu = menuRepository.findByIdAndUserId(menuId, userId);
-
-        OwnedMenuSearch ownedMenuSearch = OwnedMenuSearch.builder()
-                .menuTitle(menu.getTitle())
-                .storeTitle(menu.getStore().getTitle())
-                .storeAddress(menu.getStore().getAddress())
-                .userId(userId)
-                .build();
-
-        ownedMenuSearchRepository.save(ownedMenuSearch);
-
+        saveOwnedMenuSearchHistory(userId, menu);
         return getMenuInfo(menu);
     }
-
 
     public List<MenuInfoOnMapDto> findMenuByStoreIdOnMap(Long storeId, Long userId) {
         List<Menu> menus = menuRepository.findByUserIdAndStoreId(userId, storeId);
@@ -147,5 +136,16 @@ public class MapService {
         MenuFolderInfoOnMapDto menuFolderInfo = MenuFolderInfoOnMapDto.of(latestMenuFolder, menuFolders.size());
 
         return MenuInfoOnMapDto.of(menu, menuTags, menuImgs, menuFolderInfo);
+    }
+
+    private void saveOwnedMenuSearchHistory(Long userId, Menu menu) {
+        OwnedMenuSearch ownedMenuSearch = OwnedMenuSearch.builder()
+                .menuTitle(menu.getTitle())
+                .storeTitle(menu.getStore().getTitle())
+                .storeAddress(menu.getStore().getAddress())
+                .userId(userId)
+                .build();
+
+        ownedMenuSearchRepository.save(ownedMenuSearch);
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
@@ -96,14 +96,6 @@ public class MapService {
                 .map(MapSearchDto::from)
                 .toList();
 
-        OwnedMenuSearch ownedMenuSearch = OwnedMenuSearch.builder()
-                .menuTitle(title)
-                .userId(userId)
-                .searchAt(LocalDateTime.now())
-                .build();
-
-        ownedMenuSearchRepository.save(ownedMenuSearch);
-
         return mapSearchDtos;
     }
 
@@ -120,6 +112,16 @@ public class MapService {
 
     public MenuInfoOnMapDto findMenuByMenuIdOnMap(Long menuId, Long userId) {
         Menu menu = menuRepository.findByIdAndUserId(menuId, userId);
+
+        OwnedMenuSearch ownedMenuSearch = OwnedMenuSearch.builder()
+                .menuTitle(menu.getTitle())
+                .storeTitle(menu.getStore().getTitle())
+                .storeAddress(menu.getStore().getAddress())
+                .userId(userId)
+                .searchAt(LocalDateTime.now())
+                .build();
+
+        ownedMenuSearchRepository.save(ownedMenuSearch);
 
         return getMenuInfo(menu);
     }

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
@@ -81,7 +81,7 @@ public class MapService {
         }
 
         for (Menu menu : menus) {
-            response.add(getInfo(menu));
+            response.add(getMenuInfo(menu));
         }
 
         return response;
@@ -135,7 +135,7 @@ public class MapService {
         List<MenuInfoOnMapDto> response = new ArrayList<>();
 
         for (Menu menu : menus) {
-            response.add(getInfo(menu));
+            response.add(getMenuInfo(menu));
         }
 
         return response;

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
@@ -81,16 +81,7 @@ public class MapService {
         }
 
         for (Menu menu : menus) {
-            List<MenuTag> menuTags = menuTagRepository.findMenuTagsByMenuId(menu.getId());
-            List<MenuImg> menuImgs = menuImgRepository.findAllByMenuId(menu.getId());
-            List<MenuFolder> menuFolders = menuFolderRepository.findMenuFoldersByMenuId(menu.getId());
-
-            MenuFolder latestMenuFolder = menuFolders.stream()
-                    .max(Comparator.comparing(MenuFolder::getCreatedAt)) // createdAt으로 정렬
-                    .orElseThrow(RuntimeException::new);        //예외처리 수정 필요
-
-            MenuFolderInfoOnMapDto menuFolderInfo = MenuFolderInfoOnMapDto.of(latestMenuFolder, menuFolders.size());
-            response.add(MenuInfoOnMapDto.of(menu, menuTags, menuImgs, menuFolderInfo));
+            response.add(getInfo(menu));
         }
 
         return response;
@@ -134,6 +125,23 @@ public class MapService {
     public MenuInfoOnMapDto findMenuByMenuIdOnMap(Long menuId, Long userId) {
         Menu menu = menuRepository.findByIdAndUserId(menuId, userId);
 
+        MenuInfoOnMapDto response = getInfo(menu);
+        return response;
+    }
+
+
+    public List<MenuInfoOnMapDto> findMenuByStoreIdOnMap(Long storeId, Long userId) {
+        List<Menu> menus = menuRepository.findByUserIdAndStoreId(userId, storeId);
+        List<MenuInfoOnMapDto> response = new ArrayList<>();
+
+        for (Menu menu : menus) {
+            response.add(getInfo(menu));
+        }
+
+        return response;
+    }
+
+    private MenuInfoOnMapDto getMenuInfo(Menu menu) {
         List<MenuTag> menuTags = menuTagRepository.findMenuTagsByMenuId(menu.getId());
         List<MenuImg> menuImgs = menuImgRepository.findAllByMenuId(menu.getId());
         List<MenuFolder> menuFolders = menuFolderRepository.findMenuFoldersByMenuId(menu.getId());
@@ -145,26 +153,6 @@ public class MapService {
         MenuFolderInfoOnMapDto menuFolderInfo = MenuFolderInfoOnMapDto.of(latestMenuFolder, menuFolders.size());
 
         MenuInfoOnMapDto response = MenuInfoOnMapDto.of(menu, menuTags, menuImgs, menuFolderInfo);
-        return response;
-    }
-
-    public List<MenuInfoOnMapDto> findMenuByStoreIdOnMap(Long storeId, Long userId) {
-        List<Menu> menus = menuRepository.findByUserIdAndStoreId(userId, storeId);
-        List<MenuInfoOnMapDto> response = new ArrayList<>();
-
-        for (Menu menu : menus) {
-            List<MenuTag> menuTags = menuTagRepository.findMenuTagsByMenuId(menu.getId());
-            List<MenuImg> menuImgs = menuImgRepository.findAllByMenuId(menu.getId());
-            List<MenuFolder> menuFolders = menuFolderRepository.findMenuFoldersByMenuId(menu.getId());
-
-            MenuFolder latestMenuFolder = menuFolders.stream()
-                    .max(Comparator.comparing(MenuFolder::getCreatedAt)) // createdAt으로 정렬
-                    .orElseThrow(RuntimeException::new);        //예외처리 수정 필요
-
-            MenuFolderInfoOnMapDto menuFolderInfo = MenuFolderInfoOnMapDto.of(latestMenuFolder, menuFolders.size());
-            response.add(MenuInfoOnMapDto.of(menu, menuTags, menuImgs, menuFolderInfo));
-        }
-
         return response;
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
@@ -68,14 +68,15 @@ public class MapService {
                 .orElseThrow(RuntimeException::new);    //예외처리 수정 필요
 
         List<Store> stores = map.getStores();
-        List<Menu> menus = new ArrayList<>();
+        List<Menu> menuList = new ArrayList<>();
         List<MenuInfoOnMapDto> menuInfoOnMapDtos = new ArrayList<>();
 
         for (Store store : stores) {
-            menus = menuRepository.findMenusByStoreIdAndUserId(store.getId(), userId);
+            List<Menu> findMenuList = menuRepository.findMenusByStoreIdAndUserId(store.getId(), userId);
+            menuList.addAll(findMenuList);
         }
 
-        for (Menu menu : menus) {
+        for (Menu menu : menuList) {
             menuInfoOnMapDtos.add(getMenuInfo(menu));
         }
 

--- a/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuFolderRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuFolderRepository.java
@@ -30,4 +30,9 @@ public interface MenuFolderRepository extends JpaRepository<MenuFolder, Long> {
             "WHERE m.userId = :userId AND m.index BETWEEN :start AND :end")
     void decrementIndexes(@Param("userId") Long userId, @Param("start") int start, @Param("end") int end);
 
+    @Query("SELECT DISTINCT mf FROM MenuFolder mf " +
+            "JOIN FETCH MenuMenuFolder mmf ON mf.id = mmf.folderId "+
+            "JOIN FETCH mmf.menu m " +
+            "WHERE m.id = :menuId")
+    List<MenuFolder> findMenuFoldersByMenuId(@Param("menuId") Long menuId);
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuFolderRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuFolderRepository.java
@@ -32,7 +32,6 @@ public interface MenuFolderRepository extends JpaRepository<MenuFolder, Long> {
 
     @Query("SELECT DISTINCT mf FROM MenuFolder mf " +
             "JOIN MenuMenuFolder mmf ON mf.id = mmf.folderId "+
-//            "JOIN FETCH mmf.menu m " +
             "WHERE mmf.menu.id = :menuId")
     List<MenuFolder> findMenuFoldersByMenuId(@Param("menuId") Long menuId);
 

--- a/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuFolderRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuFolderRepository.java
@@ -31,8 +31,8 @@ public interface MenuFolderRepository extends JpaRepository<MenuFolder, Long> {
     void decrementIndexes(@Param("userId") Long userId, @Param("start") int start, @Param("end") int end);
 
     @Query("SELECT DISTINCT mf FROM MenuFolder mf " +
-            "JOIN FETCH MenuMenuFolder mmf ON mf.id = mmf.folderId "+
-            "JOIN FETCH mmf.menu m " +
-            "WHERE m.id = :menuId")
+            "JOIN MenuMenuFolder mmf ON mf.id = mmf.folderId "+
+//            "JOIN FETCH mmf.menu m " +
+            "WHERE mmf.menu.id = :menuId")
     List<MenuFolder> findMenuFoldersByMenuId(@Param("menuId") Long menuId);
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
@@ -5,8 +5,14 @@ import com.ourmenu.backend.domain.store.domain.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     boolean existsByStore(Store store);
+
+    List<Menu> findMenusByUserId(Long userId);
+
+    List<Menu> findMenusByStoreIdAndUserId(Long storeId, Long userId);
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
@@ -17,4 +17,8 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
     List<Menu> findMenusByStoreIdAndUserId(Long storeId, Long userId);
 
     boolean existsByUserIdAndId(Long userId, Long id);
+
+    Menu findByIdAndUserId(Long menuId, Long userId);
+
+    List<Menu> findByUserIdAndStoreId(Long userId, Long storeId);
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/domain/Menu.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/domain/Menu.java
@@ -32,7 +32,7 @@ public class Menu extends BaseEntity {
     @NotNull
     private Integer price;
 
-    private int pin;
+    private String pin;
 
     private String memoTitle;
 

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MapSearchDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MapSearchDto.java
@@ -1,0 +1,25 @@
+package com.ourmenu.backend.domain.menu.dto;
+
+import com.ourmenu.backend.domain.menu.domain.Menu;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class MapSearchDto {
+
+    private String menuTitle;
+    private String storeTitle;
+    private String storeAddress;
+
+    public static MapSearchDto from(Menu menu){
+        return MapSearchDto.builder()
+                .menuTitle(menu.getTitle())
+                .storeTitle(menu.getStore().getTitle())
+                .storeAddress(menu.getStore().getAddress())
+                .build();
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MapSearchDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MapSearchDto.java
@@ -1,14 +1,15 @@
 package com.ourmenu.backend.domain.menu.dto;
 
 import com.ourmenu.backend.domain.menu.domain.Menu;
+import com.ourmenu.backend.domain.search.domain.OwnedMenuSearch;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MapSearchDto {
 
     private String menuTitle;
@@ -20,6 +21,14 @@ public class MapSearchDto {
                 .menuTitle(menu.getTitle())
                 .storeTitle(menu.getStore().getTitle())
                 .storeAddress(menu.getStore().getAddress())
+                .build();
+    }
+
+    public static MapSearchDto from(OwnedMenuSearch ownedMenuSearch){
+        return MapSearchDto.builder()
+                .menuTitle(ownedMenuSearch.getMenuTitle())
+                .storeTitle(ownedMenuSearch.getStoreTitle())
+                .storeAddress(ownedMenuSearch.getStoreAddress())
                 .build();
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MapSearchHistoryDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MapSearchHistoryDto.java
@@ -1,0 +1,29 @@
+package com.ourmenu.backend.domain.menu.dto;
+
+import com.ourmenu.backend.domain.search.domain.OwnedMenuSearch;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MapSearchHistoryDto {
+
+    private String menuTitle;
+    private String storeTitle;
+    private String storeAddress;
+    private LocalDateTime modifiedAt;
+
+    public static MapSearchHistoryDto from(OwnedMenuSearch ownedMenuSearch){
+        return MapSearchHistoryDto.builder()
+                .menuTitle(ownedMenuSearch.getMenuTitle())
+                .storeTitle(ownedMenuSearch.getStoreTitle())
+                .storeAddress(ownedMenuSearch.getStoreAddress())
+                .modifiedAt(ownedMenuSearch.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuDto.java
@@ -19,7 +19,7 @@ public class MenuDto {
     private int menuPrice;
     private String menuMemoTitle;
     private String menuMemoContent;
-    private int menuPin;
+    private String menuPin;
     private List<Long> menuFolderIds;
     private boolean isCrawled;
     private List<Tag> tags;

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderInfoOnMapDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderInfoOnMapDto.java
@@ -1,0 +1,22 @@
+package com.ourmenu.backend.domain.menu.dto;
+
+import com.ourmenu.backend.domain.menu.domain.MenuFolder;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MenuFolderInfoOnMapDto {
+
+    private String menuFolderTitle;
+    private String menuFolderIcon;
+    private int menuFolderCount;
+
+    public static MenuFolderInfoOnMapDto of(MenuFolder menuFolder, int count){
+        return MenuFolderInfoOnMapDto.builder()
+                .menuFolderTitle(menuFolder.getTitle())
+                .menuFolderIcon(menuFolder.getIcon())
+                .menuFolderCount(count)
+                .build();
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuInfoOnMapDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuInfoOnMapDto.java
@@ -1,0 +1,37 @@
+package com.ourmenu.backend.domain.menu.dto;
+
+import com.ourmenu.backend.domain.menu.domain.Menu;
+import com.ourmenu.backend.domain.menu.domain.MenuImg;
+import com.ourmenu.backend.domain.tag.domain.MenuTag;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class MenuInfoOnMapDto {
+
+    private Long menuId;
+    private String menuTitle;
+    private Integer menuPrice;
+    private List<String> menuTags;
+    private List<String> menuImgUrls;
+    private MenuFolderInfoOnMapDto menuFolderInfo;
+
+    public static MenuInfoOnMapDto of(Menu menu, List<MenuTag> menuTags, List<MenuImg> menuImgs, MenuFolderInfoOnMapDto menuFolderInfo){
+        return MenuInfoOnMapDto.builder()
+                .menuId(menu.getId())
+                .menuTitle(menu.getTitle())
+                .menuPrice(menu.getPrice())
+                .menuTags(menuTags.stream().map(
+                        menuTag -> menuTag.getTag().getTagName()
+                ).collect(Collectors.toList()))
+                .menuImgUrls(menuImgs.stream().map(
+                        menuImg -> menuImg.getImgUrl()
+                ).collect(Collectors.toList()))
+                .menuFolderInfo(menuFolderInfo)
+                .build();
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuOnMapDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuOnMapDto.java
@@ -1,0 +1,30 @@
+package com.ourmenu.backend.domain.menu.dto;
+
+import com.ourmenu.backend.domain.menu.domain.Menu;
+import com.ourmenu.backend.domain.store.domain.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class MenuOnMapDto {
+
+    private Long mapId;
+    private List<String> menuPins;
+    private Double latitude;
+    private Double longitude;
+
+    public static MenuOnMapDto from(Map map, List<Menu> menus){
+        return MenuOnMapDto.builder()
+                .mapId(map.getId())
+                .menuPins(menus.stream()
+                        .map(Menu::getPin)
+                        .collect(Collectors.toList()))
+                .latitude(map.getMapX())
+                .longitude(map.getMapY())
+                .build();
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuOnMapDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuOnMapDto.java
@@ -14,8 +14,8 @@ public class MenuOnMapDto {
 
     private Long mapId;
     private List<String> menuPins;
-    private Double latitude;
-    private Double longitude;
+    private Double mapX;
+    private Double mapY;
 
     public static MenuOnMapDto from(Map map, List<Menu> menus){
         return MenuOnMapDto.builder()
@@ -23,8 +23,8 @@ public class MenuOnMapDto {
                 .menuPins(menus.stream()
                         .map(Menu::getPin)
                         .collect(Collectors.toList()))
-                .latitude(map.getMapX())
-                .longitude(map.getMapY())
+                .mapX(map.getMapX())
+                .mapY(map.getMapY())
                 .build();
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuRequest.java
@@ -11,7 +11,7 @@ public class SaveMenuRequest {
 
     private String menuTitle;
     private int menuPrice;
-    private int menuPin;
+    private String menuPin;
     private String menuMemoTitle;
     private String menuMemoContent;
     private List<Long> menuFolderIds;

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuResponse.java
@@ -22,7 +22,7 @@ public class SaveMenuResponse {
     private int menuPrice;
     private String menuMemoTitle;
     private String menuMemoContent;
-    private int menuPin;
+    private String menuPin;
     private List<Long> menuFolderIds;
     private boolean isCrawled;
     private List<String> tags;

--- a/src/main/java/com/ourmenu/backend/domain/search/dao/OwnedMenuSearchRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dao/OwnedMenuSearchRepository.java
@@ -4,8 +4,18 @@ import com.ourmenu.backend.domain.search.domain.OwnedMenuSearch;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface OwnedMenuSearchRepository extends JpaRepository<OwnedMenuSearch, Long> {
 
+    @Query(value = "SELECT o FROM OwnedMenuSearch o " +
+            "WHERE o.modifiedAt IN ( " +
+            "    SELECT MAX(sub.modifiedAt) " +
+            "    FROM OwnedMenuSearch sub " +
+            "    WHERE sub.userId = :userId " +
+            "    GROUP BY sub.menuTitle, sub.storeTitle " +
+            ") " +
+            "AND o.userId = :userId " +
+            "ORDER BY o.modifiedAt DESC")
     Page<OwnedMenuSearch> findByUserIdOrderByModifiedAtDesc(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/dao/OwnedMenuSearchRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dao/OwnedMenuSearchRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OwnedMenuSearchRepository extends JpaRepository<OwnedMenuSearch, Long> {
 
-    Page<OwnedMenuSearch> findByUserIdOrderBySearchAtDesc(Long userId, Pageable pageable);
+    Page<OwnedMenuSearch> findByUserIdOrderByModifiedAtDesc(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/ourmenu/backend/domain/search/dao/OwnedMenuSearchRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dao/OwnedMenuSearchRepository.java
@@ -1,0 +1,11 @@
+package com.ourmenu.backend.domain.search.dao;
+
+import com.ourmenu.backend.domain.search.domain.OwnedMenuSearch;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OwnedMenuSearchRepository extends JpaRepository<OwnedMenuSearch, Long> {
+
+    Page<OwnedMenuSearch> findByUserIdOrderBySearchAtDesc(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/OwnedMenuSearch.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/OwnedMenuSearch.java
@@ -27,7 +27,13 @@ public class OwnedMenuSearch extends BaseEntity {
     private Long id;
 
     @NotNull
-    private String title;
+    private String menuTitle;
+
+    @NotNull
+    private String storeTitle;
+
+    @NotNull
+    private String storeAddress;
 
     @NotNull
     private LocalDateTime searchAt;

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/OwnedMenuSearch.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/OwnedMenuSearch.java
@@ -36,8 +36,5 @@ public class OwnedMenuSearch extends BaseEntity {
     private String storeAddress;
 
     @NotNull
-    private LocalDateTime searchAt;
-
-    @NotNull
     private Long userId;
 }

--- a/src/main/java/com/ourmenu/backend/domain/store/dao/MapRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/store/dao/MapRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface MapRepository extends JpaRepository<Map, Long> {
 
     Optional<Map> findByMapXAndMapY(Double mapX, Double mapY);
+
+    Optional<Map> findMapById(Long mapId);
 }

--- a/src/main/java/com/ourmenu/backend/domain/store/domain/Map.java
+++ b/src/main/java/com/ourmenu/backend/domain/store/domain/Map.java
@@ -2,17 +2,18 @@ package com.ourmenu.backend.domain.store.domain;
 
 import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -31,6 +32,6 @@ public class Map extends BaseEntity {
     @NotNull
     private Double mapY;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Store store;
+    @OneToMany(mappedBy = "map")
+    private List<Store> stores;
 }

--- a/src/main/java/com/ourmenu/backend/domain/store/domain/Store.java
+++ b/src/main/java/com/ourmenu/backend/domain/store/domain/Store.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -29,6 +30,6 @@ public class Store extends BaseEntity {
 
     private String address;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Map map;
 }

--- a/src/main/java/com/ourmenu/backend/domain/tag/dao/MenuTagRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/tag/dao/MenuTagRepository.java
@@ -4,8 +4,12 @@ import com.ourmenu.backend.domain.tag.domain.MenuTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MenuTagRepository extends JpaRepository<MenuTag, Long> {
 
     void deleteAllByMenuId(Long menuId);
+
+    List<MenuTag> findMenuTagsByMenuId(Long menuId);
 }


### PR DESCRIPTION
### ✏️ 작업 개요
- #24 

### ⛳ 작업 분류
- [x] 작업1 GET /api/users/menus/maps
- [x] 작업2 GET /api/users/menus/{mapId}/maps
- [x] 작업3 GET /api/users/menus/maps/search
- [x] 작업4 GET /api/users/menus/maps/{menuId}/search
- [x] 작업5 GET /api/users/menus/maps/search-history

### 🔨 작업 상세 내용
1. 지도 API (메뉴핀 조회, MapID 조회, MenuID 조회, 검색, 검색 기록 조회)를 구현하였습니다.
2. Map과 Store의 연관관계를 수정하였습니다.(일대다 관계)
3. OwnedMenuSearch 엔티티의 필드값을 수정하였습니다.(searchAt 삭제)

### 💡 생각해볼 문제
- 현재 예외처리가 제대로 이루어지지 않아 오류사항에 대한 확인이 어렵습니다. 
- MapService 레이어에서 총 8개의 Repository를 사용하고 있는데, 이런 구조로 사용하는게 맞는지 확인해주시면 좋을 것 같아요.
- MapRepository에서 findByUserIdOrderByModiedAtDesc에서의 쿼리를 작성하였는데, 이와 같이 DB에서 가져오는 시점에 중복을 처리하는 방법과 우선 검색 기록을 가져온 뒤 Service 레이어에서 중복 처리를 하는 것이 맞을 지에 대한 고민이 있었습니다.
