### PR TITLE
[Fix] form-data 형식 변경

### DIFF
--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MenuController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MenuController.java
@@ -9,17 +9,15 @@ import com.ourmenu.backend.domain.search.dto.SimpleSearchDto;
 import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
 import com.ourmenu.backend.global.response.ApiResponse;
 import com.ourmenu.backend.global.response.util.ApiUtil;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/menu")
@@ -30,11 +28,10 @@ public class MenuController {
     private final SearchService searchService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<SaveMenuResponse> saveMenu(@RequestPart("data") SaveMenuRequest request,
-                                                  @RequestPart(value = "menuFolderImgs", required = false) List<MultipartFile> menuFolderImgs,
+    public ApiResponse<SaveMenuResponse> saveMenu(@ModelAttribute SaveMenuRequest request,
                                                   @AuthenticationPrincipal CustomUserDetails userDetails) {
         SimpleSearchDto simpleSearchDto = searchService.getSearchDto(request.isCrawled(), request.getStoreId());
-        MenuDto menuDto = MenuDto.of(request, menuFolderImgs, userDetails, simpleSearchDto);
+        MenuDto menuDto = MenuDto.of(request, request.getMenuFolderImgs(), userDetails, simpleSearchDto);
         SaveMenuResponse response = menuService.saveMenu(menuDto);
         return ApiUtil.success(response);
     }

--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MenuFolderController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MenuFolderController.java
@@ -17,14 +17,13 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/menu-folders")
@@ -34,26 +33,25 @@ public class MenuFolderController {
     private final MenuFolderService menuFolderService;
 
     @GetMapping
-    public ApiResponse<List<GetMenuFolderResponse>> getMenuFolder(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ApiResponse<List<GetMenuFolderResponse>> getMenuFolder(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<GetMenuFolderResponse> response = menuFolderService.findAllMenuFolder(userDetails.getId());
         return ApiUtil.success(response);
     }
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<SaveMenuFolderResponse> saveMenuFolder(@RequestPart("data") SaveMenuFolderRequest request,
-                                                              @RequestPart("menuFolderImg") MultipartFile menuFolderImg,
+    public ApiResponse<SaveMenuFolderResponse> saveMenuFolder(@ModelAttribute SaveMenuFolderRequest request,
                                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
-        MenuFolderDto menuFolderDto = MenuFolderDto.of(request, menuFolderImg, userDetails.getId());
+        MenuFolderDto menuFolderDto = MenuFolderDto.of(request, request.getMenuFolderImg(), userDetails.getId());
         SaveMenuFolderResponse response = menuFolderService.saveMenuFolder(menuFolderDto);
         return ApiUtil.success(response);
     }
 
     @PatchMapping(value = "/{menuFolderId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<UpdateMenuFolderResponse> updateMenuFolder(@PathVariable("menuFolderId") Long menuFolderId,
-                                                                  @RequestPart("data") UpdateMenuFolderRequest request,
-                                                                  @RequestPart("menuFolderImg") MultipartFile menuFolderImg,
+                                                                  @ModelAttribute UpdateMenuFolderRequest request,
                                                                   @AuthenticationPrincipal CustomUserDetails userDetails) {
-        MenuFolderDto menuFolderDto = MenuFolderDto.of(request, menuFolderImg, userDetails.getId());
+        MenuFolderDto menuFolderDto = MenuFolderDto.of(request, request.getMenuFolderImg(), userDetails.getId());
         UpdateMenuFolderResponse updateMenuFolderResponse = menuFolderService.updateMenuFolder(userDetails.getId(),
                 menuFolderId, menuFolderDto);
         return ApiUtil.success(updateMenuFolderResponse);

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/validator/MenuFolderValidator.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/validator/MenuFolderValidator.java
@@ -21,7 +21,7 @@ public class MenuFolderValidator {
      */
     @Transactional(readOnly = true)
     public void validateExistMenuFolder(Long userId, Long menuFolderId) {
-        if (!menuFolderRepository.existsByUserIdAndId(menuFolderId, userId)) {
+        if (!menuFolderRepository.existsByUserIdAndId(userId, menuFolderId)) {
             throw new ForbiddenMenuFolderException();
         }
     }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuFolderRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuFolderRequest.java
@@ -1,13 +1,15 @@
 package com.ourmenu.backend.domain.menu.dto;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class SaveMenuFolderRequest {
 
+    private MultipartFile menuFolderImg;
     private String menuFolderTitle;
     private String menuFolderIcon;
     private List<Long> menuIds;

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuRequest.java
@@ -3,13 +3,15 @@ package com.ourmenu.backend.domain.menu.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ourmenu.backend.domain.tag.domain.Tag;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class SaveMenuRequest {
 
+    List<MultipartFile> menuFolderImgs;
     private String menuTitle;
     private int menuPrice;
     private String menuPin;

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/UpdateMenuFolderRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/UpdateMenuFolderRequest.java
@@ -1,15 +1,15 @@
 package com.ourmenu.backend.domain.menu.dto;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import org.springframework.web.multipart.MultipartFile;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
-@ToString
 public class UpdateMenuFolderRequest {
 
+    private MultipartFile menuFolderImg;
     private String menuFolderTitle;
     private String menuFolderIcon;
     private List<Long> menuIds;


### PR DESCRIPTION
### ✏️ 작업 개요
- #37 

### ⛳ 작업 분류
- [x] request 형식 변경 
- [x] 버그 수정 

### 🔨 작업 상세 내용
1. formdata 형식을 기존의 multipart + data 조합에서 -> request 으로 변경하였습니다
2. 메뉴판 권한 확인 관련 버그를 수정하였습니다
3. API 명세서 수정했습니다.

### 💡 생각해볼 문제
- 예전에 개발할때 form-data에서는 list를 제대로 바인딩하지 못한다고 생각했는데, ModelAttribute에서 기본 생성자의 경우 Setter를 필요로 하기 때문에 null 처리되는 것이였습니다.
- postman에서 fom-data 입력에 대해서 주의가 필요합니다.
- 피드백 내용을 하나의 issue로 합치기에 무리가 있어서 이런식으로 진행할 거 같습니다
