### PR TITLE
[Fix] 캐시 타입 적용

### DIFF
--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MenuController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MenuController.java
@@ -73,7 +73,7 @@ public class MenuController {
     @Operation(summary = "메뉴 리스트 조회", description = "메뉴 리스트를 조회한다. 필터를 사용할 수 있다")
     @GetMapping("/menus")
     public ApiResponse<List<GetSimpleMenuResponse>> getMenus(
-            @RequestParam("tags") List<com.ourmenu.backend.domain.tag.domain.Tag> tags,
+            @RequestParam(value = "tags", required = false) List<com.ourmenu.backend.domain.tag.domain.Tag> tags,
             @RequestParam(value = "minPrice", required = false) Long minPrice,
             @RequestParam(value = "maxPrice", required = false) Long maxPrice,
             @RequestParam(value = "page", defaultValue = "0") int page,

--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MenuController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MenuController.java
@@ -43,6 +43,7 @@ public class MenuController {
     @PostMapping(path = "/menu", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<SaveMenuResponse> saveMenu(@ModelAttribute SaveMenuRequest request,
                                                   @AuthenticationPrincipal CustomUserDetails userDetails) {
+        request.initList();
         SimpleSearchDto simpleSearchDto = searchService.getSearchDto(request.isCrawled(), request.getStoreId());
         MenuDto menuDto = MenuDto.of(request, request.getMenuFolderImgs(), userDetails, simpleSearchDto);
         SaveMenuResponse response = menuService.saveMenu(menuDto);

--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MenuFolderController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MenuFolderController.java
@@ -47,6 +47,7 @@ public class MenuFolderController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<SaveMenuFolderResponse> saveMenuFolder(@ModelAttribute SaveMenuFolderRequest request,
                                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
+        request.initList();
         MenuFolderDto menuFolderDto = MenuFolderDto.of(request, request.getMenuFolderImg(), userDetails.getId());
         SaveMenuFolderResponse response = menuFolderService.saveMenuFolder(menuFolderDto);
         return ApiUtil.success(response);

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MenuImgService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MenuImgService.java
@@ -2,6 +2,7 @@ package com.ourmenu.backend.domain.menu.application;
 
 import com.ourmenu.backend.domain.menu.dao.MenuImgRepository;
 import com.ourmenu.backend.domain.menu.domain.MenuImg;
+import com.ourmenu.backend.domain.menu.util.DefaultImgConverter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,22 +15,18 @@ public class MenuImgService {
 
     private final MenuImgRepository menuImgRepository;
     private final AwsS3Service awsS3Service;
+    private final DefaultImgConverter defaultImgConverter;
 
     @Transactional
     public List<MenuImg> saveMenuImgs(Long menuId, List<MultipartFile> multipartFiles) {
-        return multipartFiles.stream()
+        List<MenuImg> menuImgs = multipartFiles.stream()
                 .map(awsS3Service::uploadFileAsync)
                 .map(imgUrl -> this.saveMenuImg(menuId, imgUrl))
                 .toList();
-    }
-
-
-    private MenuImg saveMenuImg(Long menuId, String imgUrl) {
-        MenuImg menuImg = MenuImg.builder()
-                .menuId(menuId)
-                .imgUrl(imgUrl)
-                .build();
-        return menuImgRepository.save(menuImg);
+        if (menuImgs.size() == 0) {
+            return List.of(createDefaultMenuImg());
+        }
+        return menuImgs;
     }
 
     /**
@@ -69,5 +66,25 @@ public class MenuImgService {
         return menuImgRepository.findAllByMenuId(menuId).stream()
                 .map(MenuImg::getImgUrl)
                 .toList();
+    }
+
+    private MenuImg saveMenuImg(Long menuId, String imgUrl) {
+        MenuImg menuImg = MenuImg.builder()
+                .menuId(menuId)
+                .imgUrl(imgUrl)
+                .build();
+        return menuImgRepository.save(menuImg);
+    }
+
+    /**
+     * 기본 이미지 생성
+     *
+     * @return
+     */
+    private MenuImg createDefaultMenuImg() {
+        return MenuImg.builder()
+                .menuId(null)
+                .imgUrl(defaultImgConverter.getDefaultMenuImgUrl())
+                .build();
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MenuImgService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MenuImgService.java
@@ -52,7 +52,7 @@ public class MenuImgService {
         return menuImgRepository.findAllByMenuId(menuId).stream()
                 .map(MenuImg::getImgUrl)
                 .findFirst()
-                .orElse("default.jpg");
+                .orElse(defaultImgConverter.getDefaultMenuImgUrl());
     }
 
     /**

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MenuImgService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MenuImgService.java
@@ -56,16 +56,20 @@ public class MenuImgService {
     }
 
     /**
-     * 메뉴 이미지 조회
+     * 메뉴 이미지 조회 없으면 기본 이미지 반환
      *
      * @param menuId
      * @return
      */
     @Transactional
     public List<String> findImgUrls(Long menuId) {
-        return menuImgRepository.findAllByMenuId(menuId).stream()
+        List<String> menuImgs = menuImgRepository.findAllByMenuId(menuId).stream()
                 .map(MenuImg::getImgUrl)
                 .toList();
+        if (menuImgs.size() == 0) {
+            return List.of(createDefaultMenuImg().getImgUrl());
+        }
+        return menuImgs;
     }
 
     private MenuImg saveMenuImg(Long menuId, String imgUrl) {

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MenuService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MenuService.java
@@ -204,9 +204,9 @@ public class MenuService {
         Menu menu = menuRepository.findByIdWithStore(userId, menuId)
                 .orElseThrow(NotFoundMenuException::new);
         List<String> imgUrls = menuImgService.findImgUrls(menuId);
-        List<String> tagNames = menuTagService.findTagNames(menuId);
+        List<Tag> tags = menuTagService.findTagNames(menuId);
         List<MenuFolder> menuFolders = menuFolderService.findAllByMenuId(menuId);
-        return GetMenuResponse.of(menu, imgUrls, tagNames, menuFolders);
+        return GetMenuResponse.of(menu, imgUrls, tags, menuFolders);
     }
 
     private List<Tag> saveTags(List<Tag> tags, Long menuId) {

--- a/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
@@ -74,8 +74,7 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     @Query("SELECT m FROM Menu m JOIN m.store s " +
             "WHERE m.userId = :userId " +
-            "AND m.price BETWEEN COALESCE(:minPrice, 0) AND COALESCE(:maxPrice, 2147483647) " +
-            "ORDER BY m.createdAt DESC")
+            "AND m.price BETWEEN COALESCE(:minPrice, 0) AND COALESCE(:maxPrice, 2147483647) ")
     Page<Menu> findByUserId(
             @Param("userId") Long userId,
             @Param("minPrice") Long minPrice,

--- a/src/main/java/com/ourmenu/backend/domain/menu/domain/Menu.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/domain/Menu.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.domain;
 
+import com.ourmenu.backend.domain.cache.domain.MenuPin;
 import com.ourmenu.backend.domain.store.domain.Store;
 import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
@@ -32,7 +33,7 @@ public class Menu extends BaseEntity {
     @NotNull
     private Integer price;
 
-    private String pin;
+    private MenuPin pin;
 
     private String memoTitle;
 

--- a/src/main/java/com/ourmenu/backend/domain/menu/domain/MenuFolder.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/domain/MenuFolder.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.domain;
 
+import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
 import com.ourmenu.backend.domain.menu.dto.MenuFolderDto;
 import com.ourmenu.backend.global.domain.BaseEntity;
 import jakarta.persistence.Column;
@@ -32,7 +33,7 @@ public class MenuFolder extends BaseEntity {
 
     private String imgUrl;
 
-    private String icon;
+    private MenuFolderIcon icon;
 
     @NotNull
     @Column(name = "custom_index")
@@ -47,7 +48,7 @@ public class MenuFolder extends BaseEntity {
             this.title = title;
         }
 
-        String icon = menuFolderDto.getMenuFolderIcon();
+        MenuFolderIcon icon = menuFolderDto.getMenuFolderIcon();
         if (icon != null) {
             this.icon = icon;
         }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuFolderResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuFolderResponse.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
+import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
 import com.ourmenu.backend.domain.menu.domain.MenuMenuFolder;
 import java.util.List;
@@ -16,7 +17,7 @@ public class GetMenuFolderResponse {
     private Long menuFolderId;
     private String menuFolderTitle;
     private String menuFolderUrl;
-    private String menuFolderIcon;
+    private MenuFolderIcon menuFolderIcon;
     private List<Long> menuIds;
     private int index;
 

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuResponse.java
@@ -1,6 +1,7 @@
 package com.ourmenu.backend.domain.menu.dto;
 
 import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
+import com.ourmenu.backend.domain.cache.domain.MenuPin;
 import com.ourmenu.backend.domain.menu.domain.Menu;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
 import java.util.List;
@@ -17,7 +18,7 @@ public class GetMenuResponse {
     private Long menuId;
     private String menuTitle;
     private int menuPrice;
-    private String menuPin;
+    private MenuPin menuPin;
     private String storeTitle;
     private String storeAddress;
     private List<String> tags;

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuResponse.java
@@ -4,6 +4,7 @@ import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
 import com.ourmenu.backend.domain.cache.domain.MenuPin;
 import com.ourmenu.backend.domain.menu.domain.Menu;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
+import com.ourmenu.backend.domain.tag.domain.Tag;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -21,7 +22,7 @@ public class GetMenuResponse {
     private MenuPin menuPin;
     private String storeTitle;
     private String storeAddress;
-    private List<String> tags;
+    private List<Tag> tags;
     private List<String> menuImgUrls;
 
     private List<SimpleMenuFolder> menuFolders;
@@ -35,7 +36,7 @@ public class GetMenuResponse {
         private MenuFolderIcon menuFolderIcon;
     }
 
-    public static GetMenuResponse of(Menu menu, List<String> imgUrls, List<String> tagNames,
+    public static GetMenuResponse of(Menu menu, List<String> imgUrls, List<Tag> tags,
                                      List<MenuFolder> menuFolders) {
         List<SimpleMenuFolder> simpleMenuFolders = menuFolders.stream()
                 .map(menuFolder -> SimpleMenuFolder.builder()
@@ -51,7 +52,7 @@ public class GetMenuResponse {
                 .menuPin(menu.getPin())
                 .storeAddress(menu.getStore().getAddress())
                 .storeTitle(menu.getStore().getTitle())
-                .tags(tagNames)
+                .tags(tags)
                 .menuImgUrls(imgUrls)
                 .menuFolders(simpleMenuFolders)
                 .build();

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuResponse.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
+import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
 import com.ourmenu.backend.domain.menu.domain.Menu;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
 import java.util.List;
@@ -30,7 +31,7 @@ public class GetMenuResponse {
     private static class SimpleMenuFolder {
         private Long menuFolderId;
         private String menuFolderTitle;
-        private String menuFolderIcon;
+        private MenuFolderIcon menuFolderIcon;
     }
 
     public static GetMenuResponse of(Menu menu, List<String> imgUrls, List<String> tagNames,

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuDto.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
+import com.ourmenu.backend.domain.cache.domain.MenuPin;
 import com.ourmenu.backend.domain.search.dto.SimpleSearchDto;
 import com.ourmenu.backend.domain.tag.domain.Tag;
 import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
@@ -20,7 +21,7 @@ public class MenuDto {
     private int menuPrice;
     private String menuMemoTitle;
     private String menuMemoContent;
-    private String menuPin;
+    private MenuPin menuPin;
     private List<Long> menuFolderIds;
     private String storeId;
     private boolean isCrawled;

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFilterDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFilterDto.java
@@ -2,6 +2,7 @@ package com.ourmenu.backend.domain.menu.dto;
 
 import com.ourmenu.backend.domain.menu.domain.SortOrder;
 import com.ourmenu.backend.domain.tag.domain.Tag;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -34,6 +35,9 @@ public class MenuFilterDto {
 
     public static MenuFilterDto from(List<Tag> tags, Long minPrice, Long maxPrice, int page, int size,
                                      SortOrder sortOrder) {
+        if (tags == null) {
+            tags = new ArrayList<>();
+        }
         Pageable pageable = PageRequest.of(page, size, Sort.by(sortOrder.getDirection(), sortOrder.getField()));
         return MenuFilterDto.builder()
                 .tags(tags)

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderDto.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
+import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -14,7 +15,7 @@ public class MenuFolderDto {
 
     private MultipartFile menuFolderImg;
     private String menuFolderTitle;
-    private String menuFolderIcon;
+    private MenuFolderIcon menuFolderIcon;
     private List<Long> menuIds;
     private Long userId;
 

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderInfoOnMapDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderInfoOnMapDto.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
+import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,10 +10,10 @@ import lombok.Getter;
 public class MenuFolderInfoOnMapDto {
 
     private String menuFolderTitle;
-    private String menuFolderIcon;
+    private MenuFolderIcon menuFolderIcon;
     private int menuFolderCount;
 
-    public static MenuFolderInfoOnMapDto of(MenuFolder menuFolder, int count){
+    public static MenuFolderInfoOnMapDto of(MenuFolder menuFolder, int count) {
         return MenuFolderInfoOnMapDto.builder()
                 .menuFolderTitle(menuFolder.getTitle())
                 .menuFolderIcon(menuFolder.getIcon())

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuInfoOnMapDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuInfoOnMapDto.java
@@ -3,6 +3,7 @@ package com.ourmenu.backend.domain.menu.dto;
 import com.ourmenu.backend.domain.menu.domain.Menu;
 import com.ourmenu.backend.domain.menu.domain.MenuImg;
 import com.ourmenu.backend.domain.tag.domain.MenuTag;
+import com.ourmenu.backend.domain.tag.domain.Tag;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Builder;
@@ -15,7 +16,7 @@ public class MenuInfoOnMapDto {
     private Long menuId;
     private String menuTitle;
     private Integer menuPrice;
-    private List<String> menuTags;
+    private List<Tag> menuTags;
     private List<String> menuImgUrls;
     private MenuFolderInfoOnMapDto menuFolderInfo;
 
@@ -26,7 +27,7 @@ public class MenuInfoOnMapDto {
                 .menuTitle(menu.getTitle())
                 .menuPrice(menu.getPrice())
                 .menuTags(menuTags.stream().map(
-                        menuTag -> menuTag.getTag().getTagName()
+                        MenuTag::getTag
                 ).collect(Collectors.toList()))
                 .menuImgUrls(menuImgs.stream().map(
                         menuImg -> menuImg.getImgUrl()

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuOnMapDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuOnMapDto.java
@@ -1,23 +1,23 @@
 package com.ourmenu.backend.domain.menu.dto;
 
+import com.ourmenu.backend.domain.cache.domain.MenuPin;
 import com.ourmenu.backend.domain.menu.domain.Menu;
 import com.ourmenu.backend.domain.store.domain.Map;
-import lombok.Builder;
-import lombok.Getter;
-
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
 
 @Getter
 @Builder
 public class MenuOnMapDto {
 
     private Long mapId;
-    private List<String> menuPins;
+    private List<MenuPin> menuPins;
     private Double mapX;
     private Double mapY;
 
-    public static MenuOnMapDto from(Map map, List<Menu> menus){
+    public static MenuOnMapDto from(Map map, List<Menu> menus) {
         return MenuOnMapDto.builder()
                 .mapId(map.getId())
                 .menuPins(menus.stream()

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuFolderRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuFolderRequest.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
+import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,6 +12,6 @@ public class SaveMenuFolderRequest {
 
     private MultipartFile menuFolderImg;
     private String menuFolderTitle;
-    private String menuFolderIcon;
+    private MenuFolderIcon menuFolderIcon;
     private List<Long> menuIds;
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuFolderRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuFolderRequest.java
@@ -1,6 +1,7 @@
 package com.ourmenu.backend.domain.menu.dto;
 
 import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,4 +15,13 @@ public class SaveMenuFolderRequest {
     private String menuFolderTitle;
     private MenuFolderIcon menuFolderIcon;
     private List<Long> menuIds;
+
+    /**
+     * request 에 null 들어오는 경우에 대해서 request 초기화 swagger 를 위한 메서드
+     */
+    public void initList() {
+        if (menuIds == null) {
+            menuIds = new ArrayList<>();
+        }
+    }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuFolderResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuFolderResponse.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
+import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
 import java.util.List;
 import lombok.AccessLevel;
@@ -15,7 +16,7 @@ public class SaveMenuFolderResponse {
     private Long menuFolderId;
     private String menuFolderTitle;
     private String menuFolderUrl;
-    private String menuFolderIcon;
+    private MenuFolderIcon menuFolderIcon;
     private List<Long> menuIds;
     private int index;
 

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuRequest.java
@@ -1,6 +1,7 @@
 package com.ourmenu.backend.domain.menu.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ourmenu.backend.domain.cache.domain.MenuPin;
 import com.ourmenu.backend.domain.tag.domain.Tag;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -14,7 +15,7 @@ public class SaveMenuRequest {
     List<MultipartFile> menuFolderImgs;
     private String menuTitle;
     private int menuPrice;
-    private String menuPin;
+    private MenuPin menuPin;
     private String menuMemoTitle;
     private String menuMemoContent;
     private List<Long> menuFolderIds;

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuRequest.java
@@ -3,6 +3,7 @@ package com.ourmenu.backend.domain.menu.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ourmenu.backend.domain.cache.domain.MenuPin;
 import com.ourmenu.backend.domain.tag.domain.Tag;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,7 +21,20 @@ public class SaveMenuRequest {
     private String menuMemoContent;
     private List<Long> menuFolderIds;
     private String storeId;
+
     @JsonProperty("isCrawled")
     private boolean isCrawled;
     private List<Tag> tags;
+
+    public void initList() {
+        if (menuFolderImgs == null) {
+            menuFolderImgs = new ArrayList<>();
+        }
+        if (menuFolderIds == null) {
+            menuFolderIds = new ArrayList<>();
+        }
+        if (tags == null) {
+            tags = new ArrayList<>();
+        }
+    }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuRequest.java
@@ -26,6 +26,9 @@ public class SaveMenuRequest {
     private boolean isCrawled;
     private List<Tag> tags;
 
+    /**
+     * request 에 null 들어오는 경우에 대해서 request 초기화 swagger 를 위한 메서드
+     */
     public void initList() {
         if (menuFolderImgs == null) {
             menuFolderImgs = new ArrayList<>();

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuResponse.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
+import com.ourmenu.backend.domain.cache.domain.MenuPin;
 import com.ourmenu.backend.domain.menu.domain.Menu;
 import com.ourmenu.backend.domain.menu.domain.MenuImg;
 import com.ourmenu.backend.domain.menu.domain.MenuMenuFolder;
@@ -22,7 +23,7 @@ public class SaveMenuResponse {
     private int menuPrice;
     private String menuMemoTitle;
     private String menuMemoContent;
-    private String menuPin;
+    private MenuPin menuPin;
     private List<Long> menuFolderIds;
     private boolean isCrawled;
     private List<String> tags;

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuResponse.java
@@ -26,7 +26,7 @@ public class SaveMenuResponse {
     private MenuPin menuPin;
     private List<Long> menuFolderIds;
     private boolean isCrawled;
-    private List<String> tags;
+    private List<Tag> tags;
     private String storeTitle;
     private String storeAddress;
     private Double storeMapX;
@@ -37,7 +37,6 @@ public class SaveMenuResponse {
                                       List<MenuMenuFolder> menuMenuFolders, List<Tag> tags) {
         List<String> menuImgUrls = menuImgs.stream().map(MenuImg::getImgUrl).toList();
         List<Long> menuFolderIds = menuMenuFolders.stream().map(MenuMenuFolder::getFolderId).toList();
-        List<String> tagIds = tags.stream().map(Tag::getTagName).toList();
         return SaveMenuResponse.builder()
                 .menuId(menu.getId())
                 .menuTitle(menu.getTitle())
@@ -47,7 +46,7 @@ public class SaveMenuResponse {
                 .menuPin(menu.getPin())
                 .menuFolderIds(menuFolderIds)
                 .isCrawled(menu.getIsCrawled())
-                .tags(tagIds)
+                .tags(tags)
                 .storeTitle(store.getTitle())
                 .storeAddress(store.getAddress())
                 .storeMapX(map.getMapX())

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/UpdateMenuFolderRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/UpdateMenuFolderRequest.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
+import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,7 +13,7 @@ public class UpdateMenuFolderRequest {
     private MultipartFile menuFolderImg;
     private Boolean isImageModified;
     private String menuFolderTitle;
-    private String menuFolderIcon;
+    private MenuFolderIcon menuFolderIcon;
     private List<Long> menuIds;
 
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/UpdateMenuFolderResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/UpdateMenuFolderResponse.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
+import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
 import com.ourmenu.backend.domain.menu.domain.MenuMenuFolder;
 import java.util.List;
@@ -16,7 +17,7 @@ public class UpdateMenuFolderResponse {
     private Long menuFolderId;
     private String menuFolderTitle;
     private String menuFolderUrl;
-    private String menuFolderIcon;
+    private MenuFolderIcon menuFolderIcon;
     private List<Long> menuIds;
     private int index;
 

--- a/src/main/java/com/ourmenu/backend/domain/menu/util/PriceUtil.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/util/PriceUtil.java
@@ -7,6 +7,9 @@ public class PriceUtil {
     }
 
     public static Long convertMinPrice(Long minPrice) {
+        if (minPrice == null) {
+            return null;
+        }
         if (minPrice.equals(5000L)) {
             return null;
         }
@@ -14,6 +17,9 @@ public class PriceUtil {
     }
 
     public static Long convertMaxPrice(Long maxPrice) {
+        if (maxPrice == null) {
+            return null;
+        }
         if (maxPrice.equals(50000L)) {
             return null;
         }

--- a/src/main/java/com/ourmenu/backend/domain/search/domain/SearchableStore.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/domain/SearchableStore.java
@@ -22,8 +22,8 @@ public class SearchableStore {
     @Field(name = "menus")
     private List<StoreMenu> storeMenus;
     private String storeId;
-    @Field(name = "mapx")
+    @Field(name = "mapX")
     private Double mapX;
-    @Field(name = "mapy")
+    @Field(name = "mapY")
     private Double mapY;
 }

--- a/src/main/java/com/ourmenu/backend/domain/tag/application/MenuTagService.java
+++ b/src/main/java/com/ourmenu/backend/domain/tag/application/MenuTagService.java
@@ -48,9 +48,9 @@ public class MenuTagService {
      * @return
      */
     @Transactional
-    public List<String> findTagNames(Long menuId) {
+    public List<Tag> findTagNames(Long menuId) {
         return menuTagRepository.findMenuTagsByMenuId(menuId).stream()
-                .map(menuTag -> menuTag.getTag().getTagName())
+                .map(menuTag -> menuTag.getTag())
                 .toList();
     }
 }


### PR DESCRIPTION
### ✏️ 작업 개요
- #40 

### ⛳ 작업 분류
- [x] 메뉴핀 타입 적용
- [x] 메뉴폴더 아이콘 타입 적용
- [x] 태그 타입 적용
- [x] swagger ui에서 발생하는 버그 수정 
- [x] 일부 버그 수정

### 🔨 작업 상세 내용
1. 캐시 ENUM 타입을 모든 API에 적용하였습니다.
2. swagger ui에서 발생되는 버그를 수정하였습니다.(form-data 바인딩 관련)
3. 테스트 도중 발견된 일부 버그를 수정하였습니다
    - 메뉴 조회시 태그 조건이 없는 경우 정렬이 제대로 안되는 현상
    - 식당 엔티티 컬럼 이름 수정(몽고)

### 💡 생각해볼 문제
- 변경 테스트 하면서 버그를 찾는 대로 수정하다 보니, 버그 내용도 PR 포함되었습니다
- 캐시 ENUM을 모든 API에 반영 하다보니 변경사항이 발생했을때 변경의 전파가 얼마나 발생하는지 확인할 수 있었습니다.(전부 다 바꿈..)
- 캐시 ENUM을 모든 request, response에 드러낼 필요는 없습니다. String 값을 줘도 무방합니다.
- 그럼에도 swagger ui에서의 용이성(Enum을 알려주면 swagger에서 사용하기 편함)때문에 모두 Enum으로 전파하였습니다
- 위에도 적었는데 swagger ui에서 request 에 emptyList VS null을 보내는 경우에 대해서 문제가 있어서 서버단에서도 null을 emptylist으로 변환하는 코드가 추가되었습니다. (menuFolder Patch의 경우에는 swagger ui에서 제한사항이 있습니다)
