### PR TITLE
[REFACTOR]  유저 API 리팩토링 및 오류 수정

### DIFF
--- a/src/main/java/com/ourmenu/backend/domain/user/api/UserController.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/api/UserController.java
@@ -4,9 +4,9 @@ import com.ourmenu.backend.domain.user.application.UserService;
 import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
 import com.ourmenu.backend.domain.user.dto.request.MealTimeRequest;
 import com.ourmenu.backend.domain.user.dto.request.PasswordRequest;
-import com.ourmenu.backend.domain.user.dto.request.SignInRequest;
-import com.ourmenu.backend.domain.user.dto.request.SignUpRequest;
-import com.ourmenu.backend.domain.user.dto.response.ReissueToken;
+import com.ourmenu.backend.domain.user.dto.request.EmailSignInRequest;
+import com.ourmenu.backend.domain.user.dto.request.EmailSignUpRequest;
+import com.ourmenu.backend.domain.user.dto.response.ReissueRequest;
 import com.ourmenu.backend.domain.user.dto.response.TokenDto;
 import com.ourmenu.backend.domain.user.dto.response.UserDto;
 import com.ourmenu.backend.global.response.ApiResponse;
@@ -35,14 +35,14 @@ public class UserController {
 
     @Operation(summary = "이메일 회원가입", description = "이메일 회원가입한다")
     @PostMapping("/sign-up")
-    private ApiResponse<Void> signUp(@Valid @RequestBody SignUpRequest signUpRequest) {
-        userService.signUp(signUpRequest);
+    private ApiResponse<Void> signUp(@Valid @RequestBody EmailSignUpRequest emailSignUpRequest) {
+        userService.signUp(emailSignUpRequest);
         return ApiUtil.successOnly();
     }
 
     @Operation(summary = "이메일 로그인", description = "이메일 로그인한다.")
     @PostMapping("/sign-in")
-    private ApiResponse<TokenDto> signIn(@Valid @RequestBody SignInRequest request, HttpServletResponse response) {
+    private ApiResponse<TokenDto> signIn(@Valid @RequestBody EmailSignInRequest request, HttpServletResponse response) {
         TokenDto tokenDto = userService.signIn(request, response);
         return ApiUtil.success(tokenDto);
     }
@@ -80,8 +80,8 @@ public class UserController {
 
     @Operation(summary = "토큰 갱신", description = "refresh 토큰을 갱신한다.")
     @PostMapping("/reissue-token")
-    private ApiResponse<TokenDto> reissueToken(@Valid @RequestBody ReissueToken reissueToken) {
-        TokenDto response = userService.reissueToken(reissueToken);
+    private ApiResponse<TokenDto> reissueToken(@Valid @RequestBody ReissueRequest reissueRequest) {
+        TokenDto response = userService.reissueToken(reissueRequest);
         return ApiUtil.success(response);
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
@@ -108,13 +108,12 @@ public class UserService {
     }
 
     /**
-     * Response Header에 AccessToken 값과 RefreshToken 값을 설정
+     * Response Header에 AccessToken 값 반환
      * @param response HTTP Response
      * @param tokenDto JWT Token 정보
      */
     private void setHeader(HttpServletResponse response, TokenDto tokenDto) {
         response.addHeader(JwtTokenProvider.ACCESS_TOKEN, tokenDto.getAccessToken());
-        response.addHeader(JwtTokenProvider.REFRESH_TOKEN, tokenDto.getRefreshToken());
     }
 
     public void changePassword(PasswordRequest request, CustomUserDetails userDetails) {

--- a/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
@@ -53,7 +53,7 @@ public class UserService {
         User user = User.builder()
                 .email(emailSignUpRequest.getEmail())
                 .password(encodedPassword)
-                .signInType(SignInType.valueOf(emailSignUpRequest.getSignInType()))
+                .signInType(SignInType.EMAIL)
                 .build();
         User savedUser = userRepository.save(user);
 

--- a/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
@@ -134,8 +134,6 @@ public class UserService {
 
     @Transactional
     public void changeMealTime(MealTimeRequest request, CustomUserDetails userDetails) {
-        log.debug("{}", userDetails.getId());
-
         mealTimeRepository.deleteAllByUserId(userDetails.getId());
 
         ArrayList<Integer> newMealTimes = request.getMealTime();

--- a/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
@@ -189,12 +189,10 @@ public class UserService {
             refreshTokenRepository.save(storedToken);
         }
 
-        return TokenDto.builder()
-                .grantType("Bearer")
-                .accessToken(newAccessToken)
-                .refreshToken(newRefreshToken)
-                .refreshTokenExpiredAt(jwtTokenProvider.getExpiredAt(newRefreshToken).toInstant())
-                .build();
+        return TokenDto.of(newAccessToken,
+                newRefreshToken,
+                jwtTokenProvider.getExpiredAt(newRefreshToken).toInstant()
+        );
     }
 
     public void signOut(HttpServletRequest request, Long userId){

--- a/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
@@ -6,9 +6,9 @@ import com.ourmenu.backend.domain.user.dao.UserRepository;
 import com.ourmenu.backend.domain.user.domain.*;
 import com.ourmenu.backend.domain.user.dto.request.MealTimeRequest;
 import com.ourmenu.backend.domain.user.dto.request.PasswordRequest;
-import com.ourmenu.backend.domain.user.dto.request.SignInRequest;
-import com.ourmenu.backend.domain.user.dto.request.SignUpRequest;
-import com.ourmenu.backend.domain.user.dto.response.ReissueToken;
+import com.ourmenu.backend.domain.user.dto.request.EmailSignInRequest;
+import com.ourmenu.backend.domain.user.dto.request.EmailSignUpRequest;
+import com.ourmenu.backend.domain.user.dto.response.ReissueRequest;
 import com.ourmenu.backend.domain.user.dto.response.TokenDto;
 import com.ourmenu.backend.domain.user.dto.response.UserDto;
 import com.ourmenu.backend.domain.user.exception.*;
@@ -39,26 +39,26 @@ public class UserService {
 
     /**
      * 이메일 중복 검사, 비밀번호 암호화 및 User 객체를 생성 후 DB에 저장
-     * @param signUpRequest User의 Email, Password, SignInType, MealTime 정보를 가진 Request
+     * @param emailSignUpRequest User의 Email, Password, SignInType, MealTime 정보를 가진 Request
      * @return 회원가입 완료
      */
-    public void signUp(SignUpRequest signUpRequest) {
+    public void signUp(EmailSignUpRequest emailSignUpRequest) {
 
-        if(userRepository.findByEmail(signUpRequest.getEmail()).isPresent()){
+        if(userRepository.findByEmail(emailSignUpRequest.getEmail()).isPresent()){
             throw new DuplicateEmailException();
         }
 
-        String encodedPassword = passwordEncoder.encode(signUpRequest.getPassword());
+        String encodedPassword = passwordEncoder.encode(emailSignUpRequest.getPassword());
 
         User user = User.builder()
-                .email(signUpRequest.getEmail())
+                .email(emailSignUpRequest.getEmail())
                 .password(encodedPassword)
-                .signInType(SignInType.valueOf(signUpRequest.getSignInType()))
+                .signInType(SignInType.valueOf(emailSignUpRequest.getSignInType()))
                 .build();
         User savedUser = userRepository.save(user);
 
         List<MealTime> mealTimes = new ArrayList<>();
-        for (Integer mealTime : signUpRequest.getMealTime()) {
+        for (Integer mealTime : emailSignUpRequest.getMealTime()) {
             MealTime newMealTime = MealTime.builder()
                     .userId(savedUser.getId())
                     .mealTime(mealTime)
@@ -77,28 +77,28 @@ public class UserService {
 
     /**
      * 로그인 로직 및 로그인 성공시 RefreshToken 갱신 후 JWT 정보 반환
-     * @param signInRequest User의 Email, Password, SignInType정보를 가진 Request
+     * @param emailSignInRequest User의 Email, Password, SignInType정보를 가진 Request
      * @param response HTTP Response
      * @return Token 정보
      */
-    public TokenDto signIn(SignInRequest signInRequest, HttpServletResponse response) {
+    public TokenDto signIn(EmailSignInRequest emailSignInRequest, HttpServletResponse response) {
 
-        User user = userRepository.findByEmail(signInRequest.getEmail()).orElseThrow(
+        User user = userRepository.findByEmail(emailSignInRequest.getEmail()).orElseThrow(
                 UserNotFoundException::new
         );
 
-        if(!passwordEncoder.matches(signInRequest.getPassword(), user.getPassword())) {
+        if(!passwordEncoder.matches(emailSignInRequest.getPassword(), user.getPassword())) {
             throw new NotMatchPasswordException();
         }
 
-        TokenDto tokenDto = jwtTokenProvider.createAllToken(signInRequest.getEmail());
+        TokenDto tokenDto = jwtTokenProvider.createAllToken(emailSignInRequest.getEmail());
 
-        Optional<RefreshToken> refreshToken = refreshTokenRepository.findRefreshTokenByEmail(signInRequest.getEmail());
+        Optional<RefreshToken> refreshToken = refreshTokenRepository.findRefreshTokenByEmail(emailSignInRequest.getEmail());
 
         if(refreshToken.isPresent()) {
             refreshTokenRepository.save(refreshToken.get().updateToken(tokenDto.getRefreshToken()));
         }else {
-            RefreshToken newToken = new RefreshToken(tokenDto.getRefreshToken(), signInRequest.getEmail());
+            RefreshToken newToken = new RefreshToken(tokenDto.getRefreshToken(), emailSignInRequest.getEmail());
             refreshTokenRepository.save(newToken);
         }
 
@@ -165,8 +165,8 @@ public class UserService {
         return UserDto.of(user, mealTimes);
     }
 
-    public TokenDto reissueToken(ReissueToken reissueToken) {
-        String refreshToken = reissueToken.getRefreshToken();
+    public TokenDto reissueToken(ReissueRequest reissueRequest) {
+        String refreshToken = reissueRequest.getRefreshToken();
         String email = jwtTokenProvider.getEmailFromToken(refreshToken);
 
         if (email.isEmpty()){
@@ -181,7 +181,7 @@ public class UserService {
                 .orElseThrow(NotMatchTokenException::new);
 
         String newAccessToken = jwtTokenProvider.createToken(email, "Access");
-        String newRefreshToken = reissueToken.getRefreshToken();
+        String newRefreshToken = reissueRequest.getRefreshToken();
 
         if (jwtTokenProvider.validateToken(refreshToken)) {
             newRefreshToken = jwtTokenProvider.createToken(email, "Refresh");

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/EmailSignInRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/EmailSignInRequest.java
@@ -3,13 +3,10 @@ package com.ourmenu.backend.domain.user.dto.request;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
-
 @Getter
 @NoArgsConstructor
-public class SignUpRequest {
+public class EmailSignInRequest {
     private String email;
     private String password;
-    private ArrayList<Integer> mealTime;
     private String signInType;
 }

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/EmailSignInRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/EmailSignInRequest.java
@@ -8,5 +8,4 @@ import lombok.NoArgsConstructor;
 public class EmailSignInRequest {
     private String email;
     private String password;
-    private String signInType;
 }

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/EmailSignUpRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/EmailSignUpRequest.java
@@ -3,10 +3,13 @@ package com.ourmenu.backend.domain.user.dto.request;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+
 @Getter
 @NoArgsConstructor
-public class SignInRequest {
+public class EmailSignUpRequest {
     private String email;
     private String password;
+    private ArrayList<Integer> mealTime;
     private String signInType;
 }

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/EmailSignUpRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/EmailSignUpRequest.java
@@ -11,5 +11,4 @@ public class EmailSignUpRequest {
     private String email;
     private String password;
     private ArrayList<Integer> mealTime;
-    private String signInType;
 }

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/response/ReissueRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/response/ReissueRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
-public class ReissueToken {
+public class ReissueRequest {
 
     @NotBlank
     private String refreshToken;

--- a/src/main/java/com/ourmenu/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/ourmenu/backend/global/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -58,5 +59,19 @@ public class SecurityConfig {
     public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
         return http.getSharedObject(AuthenticationManagerBuilder.class)
                 .build();
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring().requestMatchers(
+                    "/api/users/sign-up",
+                    "/api/users/sign-in",
+                    "/api/users/reissue-token",
+                    "/api/cache-data",
+                    "/api/emails/**",
+                    "/swagger-ui/**",
+                    "/swagger-resources/**",
+                    "/v3/api-docs/**"
+            );
     }
 }

--- a/src/main/java/com/ourmenu/backend/global/util/JwtTokenProvider.java
+++ b/src/main/java/com/ourmenu/backend/global/util/JwtTokenProvider.java
@@ -194,16 +194,6 @@ public class JwtTokenProvider {
     }
 
     /**
-     * Response의 Header에 RefreshToken값을 설정
-     *
-     * @param response     HTTP Response
-     * @param refreshToken RefreshToken값
-     */
-    public void setHeaderRefreshToken(HttpServletResponse response, String refreshToken) {
-        response.setHeader(REFRESH_TOKEN, refreshToken);
-    }
-
-    /**
      * 토큰의 만료 시간을 반환하는 메서드
      *
      * @param token JWT 토큰 값

--- a/src/main/java/com/ourmenu/backend/global/util/JwtTokenProvider.java
+++ b/src/main/java/com/ourmenu/backend/global/util/JwtTokenProvider.java
@@ -206,7 +206,7 @@ public class JwtTokenProvider {
                     .build()
                     .parseClaimsJws(token)
                     .getBody()
-                    .getExpiration(); // Claims에서 만료 시간 추출
+                    .getExpiration();
         } catch (Exception e) {
             throw new InvalidTokenException();
         }


### PR DESCRIPTION
### ✏️ 작업 개요
- #56 

### ⛳ 작업 분류
- [x] 작업1 DTO 이름 변경 및 SignInType 제거
- [x] 작업2 Header에 RefreshToken 설정 메소드 제거
- [x] 작업3 WebSecurityCustomizer 추가

### 🔨 작업 상세 내용
1. 이메일 인증에서 사용하는 DTO의 이름을 수정하였으며, OAuth와 엔드포인트 자체가 다르게 사용되므로 Request에서 SignInType을 제거하였습니다.
2. 현재 RefreshToken의 사용 용도는 Reissue뿐이며, 해당 경우 Body에 토큰값을 넣어 사용하고 있어 헤더에 RefreshToken을 넣을 필요가 없어졌습니다.
3. SecurityConfig에서  permitAll() 메소드에 해당하는 엔드포인트들이 필터를 거치며 예외를 발생시켰는데, WebSecurityCustomizer를 통해 SpringSecurity를 적용하지 않을 리소스를 설정하였습니다.

### 💡 생각해볼 문제
- OAuth를 구현하며 기존의 fix/user 브랜치의 커밋이 뒤섞여 부득이하게 새로운 브랜치를 만들게 되었습니다.
- 스프링 시큐리티는 봐도봐도 어렵네요..
