### PR TITLE
[FIX] 지도 API 검색 기능 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
     //monitoring
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    //Hibernate Spatial
+    implementation 'org.hibernate.orm:hibernate-spatial:6.2.9.Final'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
@@ -45,8 +45,10 @@ public class MapController {
     @Operation(summary = "지도 검색", description = "지도에서 메뉴를 검색한다. 메뉴 이름과 가게 이름이 검색 범주에 포함된다.")
     @GetMapping("/maps/search")
     public ApiResponse<List<MapSearchDto>> findSearchOnMap(@RequestParam String title,
+                                                           @RequestParam double mapX,
+                                                           @RequestParam double mapY,
                                                            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        List<MapSearchDto> response = mapService.findSearchResultOnMap(title, userDetails.getId());
+        List<MapSearchDto> response = mapService.findSearchResultOnMap(title, mapX, mapY, userDetails.getId());
         return ApiUtil.success(response);
     }
 

--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MapController.java
@@ -45,8 +45,8 @@ public class MapController {
     @Operation(summary = "지도 검색", description = "지도에서 메뉴를 검색한다. 메뉴 이름과 가게 이름이 검색 범주에 포함된다.")
     @GetMapping("/maps/search")
     public ApiResponse<List<MapSearchDto>> findSearchOnMap(@RequestParam String title,
-                                                           @RequestParam double mapX,
-                                                           @RequestParam double mapY,
+                                                           @RequestParam(defaultValue = "127.0759204") double mapX,
+                                                           @RequestParam(defaultValue = "37.5423265") double mapY,
                                                            @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<MapSearchDto> response = mapService.findSearchResultOnMap(title, mapX, mapY, userDetails.getId());
         return ApiUtil.success(response);

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
@@ -105,12 +105,9 @@ public class MapService {
         PageRequest pageRequest = PageRequest.of(0, 30);
 
         Page<Menu> menusByUserIdOrderByDistance =
-                menuRepository.findByUserIdContainingTitleOrderByDistance(userId, title, userLocation, pageRequest);
-        List<Menu> menus = menuRepository.findMenusByUserId(userId);
+                menuRepository.findByUserIdTitleContainingOrderByDistance(userId, title, userLocation, pageRequest);
 
-        return menus.stream()
-                .filter(m -> m.getStore().getTitle().contains(title)
-                        || m.getTitle().contains(title))
+        return menusByUserIdOrderByDistance.stream()
                 .map(MapSearchDto::from)
                 .toList();
     }

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -99,8 +100,8 @@ public class MapService {
         User user = userRepository.findById(userId)
                 .orElseThrow(NotFoundUserException::new);
 
-        Point userLocation = new GeometryFactory().createPoint(new Coordinate(mapX, mapY));
-        userLocation.setSRID(4326);
+        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+        Point userLocation = geometryFactory.createPoint(new Coordinate(mapX, mapY));
 
         PageRequest pageRequest = PageRequest.of(0, 10);
 

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
@@ -102,7 +102,7 @@ public class MapService {
         Point userLocation = new GeometryFactory().createPoint(new Coordinate(mapX, mapY));
         userLocation.setSRID(4326);
 
-        PageRequest pageRequest = PageRequest.of(0, 30);
+        PageRequest pageRequest = PageRequest.of(0, 10);
 
         Page<Menu> menusByUserIdOrderByDistance =
                 menuRepository.findByUserIdTitleContainingOrderByDistance(userId, title, userLocation, pageRequest);

--- a/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
@@ -5,6 +5,7 @@ import com.ourmenu.backend.domain.menu.dto.MenuSimpleDto;
 import com.ourmenu.backend.domain.store.domain.Store;
 import java.util.List;
 import java.util.Optional;
+import org.locationtech.jts.geom.Point;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -203,5 +204,23 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
             Pageable pageable
     );
 
+    @Query(
+            value = "SELECT m.* FROM menu m " +
+                    "JOIN store s ON m.store_id = s.id " +
+                    "JOIN map ON s.map_id = map.id " +
+                    "WHERE m.user_id = :userId " +
+                    "AND LOWER(m.title) LIKE CONCAT('%', :title, '%') " +
+                    "ORDER BY ST_Distance(map.location, :userLocation) ASC",
+            countQuery = "SELECT COUNT(*) FROM menu m " +
+                    "JOIN store s ON m.store_id = s.id " +
+                    "JOIN map ON s.map_id = map.id " +
+                    "WHERE m.user_id = :userId " +
+                    "AND LOWER(m.title) LIKE CONCAT('%', :title, '%')",
+            nativeQuery = true
+    )
+    Page<Menu> findByUserIdContainingTitleOrderByDistance(@Param("userId") Long userId,
+                                                          @Param("title") String title,
+                                                          @Param("userLocation") Point userLocation,
+                                                          Pageable pageable);
 }
 

--- a/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
@@ -267,7 +267,7 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
                     "JOIN map ON s.map_id = map.id " +
                     "WHERE m.user_id = :userId " +
                     "AND LOWER(m.title) LIKE CONCAT('%', LOWER(:title), '%') " +
-                    "ORDER BY ST_Distance(map.location, :userLocation) ASC",
+                    "ORDER BY ST_Distance_Sphere(map.location, :userLocation) ASC",
             countQuery = "SELECT COUNT(*) FROM menu m " +
                     "JOIN store s ON m.store_id = s.id " +
                     "JOIN map ON s.map_id = map.id " +

--- a/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
@@ -266,16 +266,16 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
                     "JOIN store s ON m.store_id = s.id " +
                     "JOIN map ON s.map_id = map.id " +
                     "WHERE m.user_id = :userId " +
-                    "AND LOWER(m.title) LIKE CONCAT('%', :title, '%') " +
+                    "AND LOWER(m.title) LIKE CONCAT('%', LOWER(:title), '%') " +
                     "ORDER BY ST_Distance(map.location, :userLocation) ASC",
             countQuery = "SELECT COUNT(*) FROM menu m " +
                     "JOIN store s ON m.store_id = s.id " +
                     "JOIN map ON s.map_id = map.id " +
                     "WHERE m.user_id = :userId " +
-                    "AND LOWER(m.title) LIKE CONCAT('%', :title, '%')",
+                    "AND LOWER(m.title) LIKE CONCAT('%', LOWER(:title), '%')",
             nativeQuery = true
     )
-    Page<Menu> findByUserIdContainingTitleOrderByDistance(@Param("userId") Long userId,
+    Page<Menu> findByUserIdTitleContainingOrderByDistance(@Param("userId") Long userId,
                                                           @Param("title") String title,
                                                           @Param("userLocation") Point userLocation,
                                                           Pageable pageable);

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuInfoOnMapDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuInfoOnMapDto.java
@@ -40,8 +40,8 @@ public class MenuInfoOnMapDto {
                 ).collect(Collectors.toList()))
                 .menuFolderInfo(menuFolderInfo)
                 .mapId(menu.getStore().getMap().getId())
-                .mapX(menu.getStore().getMap().getMapX())
-                .mapY(menu.getStore().getMap().getMapY())
+                .mapX(menu.getStore().getMap().getLocation().getX())
+                .mapY(menu.getStore().getMap().getLocation().getY())
                 .build();
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuOnMapDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuOnMapDto.java
@@ -23,8 +23,8 @@ public class MenuOnMapDto {
                 .menuPins(menus.stream()
                         .map(Menu::getPin)
                         .collect(Collectors.toList()))
-                .mapX(map.getMapX())
-                .mapY(map.getMapY())
+                .mapX(map.getLocation().getX())
+                .mapY(map.getLocation().getY())
                 .build();
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuResponse.java
@@ -49,8 +49,8 @@ public class SaveMenuResponse {
                 .tags(tags)
                 .storeTitle(store.getTitle())
                 .storeAddress(store.getAddress())
-                .storeMapX(map.getMapX())
-                .storeMapY(map.getMapY())
+                .storeMapX(map.getLocation().getX())
+                .storeMapY(map.getLocation().getY())
                 .menuImgUrls(menuImgUrls)
                 .build();
     }

--- a/src/main/java/com/ourmenu/backend/domain/store/application/StoreService.java
+++ b/src/main/java/com/ourmenu/backend/domain/store/application/StoreService.java
@@ -7,6 +7,9 @@ import com.ourmenu.backend.domain.store.domain.Map;
 import com.ourmenu.backend.domain.store.domain.Store;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,16 +63,16 @@ public class StoreService {
     }
 
     private Map saveMapIfNonExists(Double mapX, Double mapY) {
-        Optional<Map> optionalMap = mapRepository.findByMapXAndMapY(mapX, mapY);
+        Point location = new GeometryFactory().createPoint(new Coordinate(mapX, mapY));
+        Optional<Map> optionalMap = mapRepository.findByLocation(location);
         Map map;
+
         if (optionalMap.isPresent()) {
             return optionalMap.get();
-
         }
 
         map = Map.builder()
-                .mapX(mapX)
-                .mapY(mapY)
+                .location(location)
                 .build();
         return mapRepository.save(map);
     }

--- a/src/main/java/com/ourmenu/backend/domain/store/application/StoreService.java
+++ b/src/main/java/com/ourmenu/backend/domain/store/application/StoreService.java
@@ -64,6 +64,7 @@ public class StoreService {
 
     private Map saveMapIfNonExists(Double mapX, Double mapY) {
         Point location = new GeometryFactory().createPoint(new Coordinate(mapX, mapY));
+        location.setSRID(4326);
         Optional<Map> optionalMap = mapRepository.findByLocation(location);
         Map map;
 

--- a/src/main/java/com/ourmenu/backend/domain/store/dao/MapRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/store/dao/MapRepository.java
@@ -2,13 +2,15 @@ package com.ourmenu.backend.domain.store.dao;
 
 import com.ourmenu.backend.domain.store.domain.Map;
 import java.util.Optional;
+
+import org.locationtech.jts.geom.Point;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MapRepository extends JpaRepository<Map, Long> {
 
-    Optional<Map> findByMapXAndMapY(Double mapX, Double mapY);
+    Optional<Map> findByLocation(Point location);
 
     Optional<Map> findMapById(Long mapId);
 }

--- a/src/main/java/com/ourmenu/backend/domain/store/domain/Map.java
+++ b/src/main/java/com/ourmenu/backend/domain/store/domain/Map.java
@@ -1,18 +1,18 @@
 package com.ourmenu.backend.domain.store.domain;
 
 import com.ourmenu.backend.global.domain.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
+import org.locationtech.jts.geom.Point;
 import java.util.List;
 
 @Entity
@@ -26,11 +26,8 @@ public class Map extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
-    private Double mapX;
-
-    @NotNull
-    private Double mapY;
+    @Column(nullable = false, columnDefinition = "POINT SRID 4326")
+    private Point location;
 
     @OneToMany(mappedBy = "map")
     private List<Store> stores;


### PR DESCRIPTION
### ✏️ 작업 개요
- #52 

### ⛳ 작업 분류
- [x] 작업1 지도 검색 API 거리 반영

### 🔨 작업 상세 내용
1. 지도에서 메뉴를 검색하는 경우 해당 메뉴가 존재하는 위치 정보와 Request로 받는 유저의 위치 정보를 비교하여 가까운 순으로 정렬하여 반환합니다.
2. 메뉴 검색 API와 동일하게 건국대 위치를 DefaultValue로 설정해두었습니다.

### 💡 생각해볼 문제
- 공간 데이터 타입 및 공간 함수만을 사용하였으나, commit 메세지에는 **공간 인덱싱 적용** 이라고 작성하였습니다.
