### PR TITLE
[FIX] 유저 회원가입 변경, Reissue 해결 및 유저 삭제 API 구현

### DIFF
--- a/src/main/java/com/ourmenu/backend/domain/home/application/RecommendMenuCacheService.java
+++ b/src/main/java/com/ourmenu/backend/domain/home/application/RecommendMenuCacheService.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +16,7 @@ public class RecommendMenuCacheService {
 
     private static final String STORE_CACHE_KEY_PREFIX = "GetRecommendMenuResponse:";
     @Autowired
+    @Qualifier("redisTemplate")
     private RedisTemplate<String, Object> redisTemplate;
 
     /**

--- a/src/main/java/com/ourmenu/backend/domain/user/api/UserController.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/api/UserController.java
@@ -97,6 +97,7 @@ public class UserController {
         return ApiUtil.success(response);
     }
 
+    @Operation(summary = "유저 삭제", description = "유저를 DB에서 삭제한다.")
     @DeleteMapping("")
     private ApiResponse<Void> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
         userService.removeUser(userDetails.getId());

--- a/src/main/java/com/ourmenu/backend/domain/user/api/UserController.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/api/UserController.java
@@ -86,7 +86,7 @@ public class UserController {
     @PostMapping("/sign-out")
     private ApiResponse<Void> signOut(HttpServletRequest request,
                                       @AuthenticationPrincipal CustomUserDetails userDetails) {
-        userService.signOut(request, userDetails.getId());
+        userService.signOut(request);
         return ApiUtil.successOnly();
     }
 

--- a/src/main/java/com/ourmenu/backend/domain/user/api/UserController.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/api/UserController.java
@@ -21,6 +21,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -94,5 +95,11 @@ public class UserController {
     private ApiResponse<TokenDto> reissueToken(@Valid @RequestBody ReissueRequest reissueRequest) {
         TokenDto response = userService.reissueToken(reissueRequest);
         return ApiUtil.success(response);
+    }
+
+    @DeleteMapping("")
+    private ApiResponse<Void> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        userService.removeUser(userDetails.getId());
+        return ApiUtil.successOnly();
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/user/api/UserController.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/api/UserController.java
@@ -39,9 +39,9 @@ public class UserController {
 
     @Operation(summary = "회원가입", description = "회원가입한다")
     @PostMapping("/sign-up")
-    private ApiResponse<Void> signUp(@Valid @RequestBody SignUpRequest request) {
-        userService.signUp(request);
-        return ApiUtil.successOnly();
+    private ApiResponse<TokenDto> signUp(@Valid @RequestBody SignUpRequest request) {
+        TokenDto response = userService.signUp(request);
+        return ApiUtil.success(response);
     }
 
     @Operation(summary = "로그인", description = "로그인한다.")

--- a/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
@@ -174,18 +174,17 @@ public class UserService {
      * 해당 유저의 RefreshToken을 제거하며 로그아웃한다.
      *
      * @param request
-     * @param userId
      */
-    public void signOut(HttpServletRequest request, Long userId) {
+    public void signOut(HttpServletRequest request) {
         String token = request.getHeader("Authorization");
-
-        if (token != null && token.startsWith("Bearer ")) {
+        if (token.startsWith("Bearer ")) {
             token = token.substring(7);
-            String email = jwtTokenProvider.getEmailFromToken(token);
-
-            refreshTokenRepository.findRefreshTokenByEmail(email)
-                    .ifPresent(refreshTokenRepository::delete);
         }
+
+        String email = jwtTokenProvider.getEmailFromToken(token);
+
+        refreshTokenRepository.findRefreshTokenByEmail(email)
+                .ifPresent(refreshTokenRepository::delete);
     }
 
     /**

--- a/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
@@ -62,7 +62,10 @@ public class UserService {
             throw new InvalidMealTimeCountException();
         }
 
-        return jwtTokenProvider.createAllToken(request.getEmail());
+        TokenDto tokenDto = jwtTokenProvider.createAllToken(request.getEmail());
+        RefreshToken refreshToken = new RefreshToken(tokenDto.getRefreshToken(), request.getEmail());
+        refreshTokenRepository.save(refreshToken);
+        return tokenDto;
     }
 
     /**

--- a/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
@@ -51,7 +51,7 @@ public class UserService {
      * @param request User의 Email, Password, SignInType, MealTime Request
      */
     @Transactional
-    public void signUp(SignUpRequest request) {
+    public TokenDto signUp(SignUpRequest request) {
 
         User savedUser = saveUser(request);
 
@@ -61,6 +61,8 @@ public class UserService {
             userRepository.delete(savedUser);
             throw new InvalidMealTimeCountException();
         }
+
+        return jwtTokenProvider.createAllToken(request.getEmail());
     }
 
     /**

--- a/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
@@ -206,6 +206,16 @@ public class UserService {
         return KakaoExistenceResponse.from(false);
     }
 
+    public void removeUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(NotFoundUserException::new);
+
+        refreshTokenRepository.findRefreshTokenByEmail(user.getEmail())
+                .ifPresent(refreshTokenRepository::delete);
+
+        userRepository.delete(user);
+    }
+
     /**
      * 유저 정보를 저장한다.
      *

--- a/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
@@ -205,6 +205,11 @@ public class UserService {
         return KakaoExistenceResponse.from(false);
     }
 
+    /**
+     * DB에서 유저를 삭제한다.
+     *
+     * @param userId
+     */
     public void removeUser(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(NotFoundUserException::new);

--- a/src/main/java/com/ourmenu/backend/global/config/RedisConfig.java
+++ b/src/main/java/com/ourmenu/backend/global/config/RedisConfig.java
@@ -3,10 +3,12 @@ package com.ourmenu.backend.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -38,6 +40,21 @@ public class RedisConfig {
         // 키는 String 타입, 값은 JSON 직렬화 방식
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+
+    @Bean
+    @Primary
+    public RedisTemplate<Object, Object> crudRepositoryRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<Object, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        // 키는 String, 값은 JDK 직렬화 방식으로 설정하여 CrudRepository와 일치시킴
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new JdkSerializationRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new JdkSerializationRedisSerializer());
 
         return template;
     }

--- a/src/main/java/com/ourmenu/backend/global/config/RedisConfig.java
+++ b/src/main/java/com/ourmenu/backend/global/config/RedisConfig.java
@@ -3,15 +3,16 @@ package com.ourmenu.backend.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@EnableRedisRepositories(redisTemplateRef = "crudRepositoryRedisTemplate")
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")
@@ -45,12 +46,10 @@ public class RedisConfig {
     }
 
     @Bean
-    @Primary
     public RedisTemplate<Object, Object> crudRepositoryRedisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<Object, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
 
-        // 키는 String, 값은 JDK 직렬화 방식으로 설정하여 CrudRepository와 일치시킴
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new JdkSerializationRedisSerializer());
         template.setHashKeySerializer(new StringRedisSerializer());


### PR DESCRIPTION
### ✏️ 작업 개요
- #57 

### ⛳ 작업 분류
- [x] 작업1 유저 회원가입 시 토큰 발급
- [x] 작업2 RedisTemplate 추가
- [x] 작업3 유저 삭제 API 구현

### 🔨 작업 상세 내용
1. 유저가 회원가입 이후 바로 홈 화면으로 이동하여 사용할 수 있도록 회원가입 시점에서도 토큰을 발급합니다.
2. 이전에 캐싱을 진행하면서 생긴 RedisTemplate의 방식이 CrudRepository 형식과 맞지 않아 RefreshToken 조회에 오류가 발생하여 이에 맞도록 Template을 추가하였습니다.
3. 유저 삭제 API를 구현하였습니다.

### 💡 생각해볼 문제
- 우선 DB 구조에서 state를 관리하고 있지 않기 때문에 유저 삭제 시 데이터는 보존되지 않습니다.
