### PR TITLE
[FiX] 메뉴판 조회 API 수정

### DIFF
--- a/src/main/java/com/ourmenu/backend/domain/menu/api/MenuFolderController.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/api/MenuFolderController.java
@@ -13,7 +13,6 @@ import com.ourmenu.backend.global.response.ApiResponse;
 import com.ourmenu.backend.global.response.util.ApiUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -37,9 +36,9 @@ public class MenuFolderController {
 
     @Operation(summary = "메뉴판 조회", description = "메뉴판 리스트를 조회한다.")
     @GetMapping
-    public ApiResponse<List<GetMenuFolderResponse>> getMenuFolder(
+    public ApiResponse<GetMenuFolderResponse> getMenuFolder(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        List<GetMenuFolderResponse> response = menuFolderService.findAllMenuFolder(userDetails.getId());
+        GetMenuFolderResponse response = menuFolderService.findAllMenuFolder(userDetails.getId());
         return ApiUtil.success(response);
     }
 

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MenuFolderService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MenuFolderService.java
@@ -1,10 +1,12 @@
 package com.ourmenu.backend.domain.menu.application;
 
 import com.ourmenu.backend.domain.menu.dao.MenuFolderRepository;
+import com.ourmenu.backend.domain.menu.dao.MenuRepository;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
 import com.ourmenu.backend.domain.menu.domain.MenuMenuFolder;
 import com.ourmenu.backend.domain.menu.dto.GetMenuFolderResponse;
 import com.ourmenu.backend.domain.menu.dto.MenuFolderDto;
+import com.ourmenu.backend.domain.menu.dto.MenuFolderResponse;
 import com.ourmenu.backend.domain.menu.dto.SaveMenuFolderResponse;
 import com.ourmenu.backend.domain.menu.dto.UpdateMenuFolderResponse;
 import com.ourmenu.backend.domain.menu.exception.ForbiddenMenuFolderException;
@@ -25,6 +27,7 @@ public class MenuFolderService {
     private final MenuFolderRepository menuFolderRepository;
     private final MenuMenuFolderService menuMenuFolderService;
     private final DefaultImgConverter defaultImgConvertor;
+    private final MenuRepository menuRepository;
 
     /**
      * 메뉴 폴더 저장
@@ -129,19 +132,21 @@ public class MenuFolderService {
      * 유저 메뉴판 정보 조회
      *
      * @param userId
-     * @return index 기준 내림 차순 메뉴판 리스
+     * @return index 기준 내림 차순 메뉴판 리스트
      */
     @Transactional
-    public List<GetMenuFolderResponse> findAllMenuFolder(Long userId) {
+    public GetMenuFolderResponse findAllMenuFolder(Long userId) {
         List<MenuFolder> menuFolders = menuFolderRepository.findAllByUserIdOrderByIndexDesc(userId);
 
-        return menuFolders.stream()
+        List<MenuFolderResponse> menuFolderResponses = menuFolders.stream()
                 .map(menuFolder -> {
                     List<MenuMenuFolder> menuMenuFolders = menuMenuFolderService.findAllByMenuFolderId(
                             menuFolder.getId());
-                    return GetMenuFolderResponse.of(menuFolder, menuMenuFolders,
+                    return MenuFolderResponse.of(menuFolder, menuMenuFolders,
                             defaultImgConvertor.getDefaultMenuFolderImgUrl());
                 }).toList();
+        int menuCount = menuRepository.countByUserId(userId);
+        return GetMenuFolderResponse.of(menuCount, menuFolderResponses);
     }
 
     @Transactional

--- a/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
@@ -29,6 +29,8 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     List<Menu> findByUserIdAndStoreId(Long userId, Long storeId);
 
+    int countByUserId(Long userId);
+
     @Query(value = """
             SELECT m.id AS menuId, m.title AS menuTitle, s.title AS storeTitle, s.address
             AS storeAddress, m.price AS menuPrice, m.created_at AS createdAt
@@ -261,6 +263,7 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
     List<MenuSimpleDto> findByUserIdAndTag(@Param("userId") Long userId,
                                            @Param("tag") String tag,
                                            Pageable pageable);
+
     @Query(
             value = "SELECT m.* FROM menu m " +
                     "JOIN store s ON m.store_id = s.id " +

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuFolderResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuFolderResponse.java
@@ -1,8 +1,5 @@
 package com.ourmenu.backend.domain.menu.dto;
 
-import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
-import com.ourmenu.backend.domain.menu.domain.MenuFolder;
-import com.ourmenu.backend.domain.menu.domain.MenuMenuFolder;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -14,30 +11,13 @@ import lombok.Getter;
 @Getter
 public class GetMenuFolderResponse {
 
-    private Long menuFolderId;
-    private String menuFolderTitle;
-    private String menuFolderUrl;
-    private MenuFolderIcon menuFolderIcon;
-    private List<Long> menuIds;
-    private int index;
+    private int menuCount;
+    List<MenuFolderResponse> menuFolders;
 
-    public static GetMenuFolderResponse of(MenuFolder menuFolder, List<MenuMenuFolder> menuFolders,
-                                           String defaultMenuFolderImgUrl) {
-        String menuFolderImgUrl = menuFolder.getImgUrl();
-        if (menuFolderImgUrl == null) {
-            menuFolderImgUrl = defaultMenuFolderImgUrl;
-        }
-
-        List<Long> menuIds = menuFolders.stream()
-                .map(menuMenuFolder -> menuMenuFolder.getMenu().getId())
-                .toList();
+    public static GetMenuFolderResponse of(int menuCount, List<MenuFolderResponse> menuFolders) {
         return GetMenuFolderResponse.builder()
-                .menuFolderId(menuFolder.getId())
-                .menuFolderTitle(menuFolder.getTitle())
-                .menuFolderUrl(menuFolderImgUrl)
-                .menuFolderIcon(menuFolder.getIcon())
-                .menuIds(menuIds)
-                .index(menuFolder.getIndex())
+                .menuCount(menuCount)
+                .menuFolders(menuFolders)
                 .build();
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderResponse.java
@@ -1,0 +1,43 @@
+package com.ourmenu.backend.domain.menu.dto;
+
+import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
+import com.ourmenu.backend.domain.menu.domain.MenuFolder;
+import com.ourmenu.backend.domain.menu.domain.MenuMenuFolder;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class MenuFolderResponse {
+
+    private Long menuFolderId;
+    private String menuFolderTitle;
+    private String menuFolderUrl;
+    private MenuFolderIcon menuFolderIcon;
+    private List<Long> menuIds;
+    private int index;
+
+    public static MenuFolderResponse of(MenuFolder menuFolder, List<MenuMenuFolder> menuFolders,
+                                        String defaultMenuFolderImgUrl) {
+        String menuFolderImgUrl = menuFolder.getImgUrl();
+        if (menuFolderImgUrl == null) {
+            menuFolderImgUrl = defaultMenuFolderImgUrl;
+        }
+
+        List<Long> menuIds = menuFolders.stream()
+                .map(menuMenuFolder -> menuMenuFolder.getMenu().getId())
+                .toList();
+        return MenuFolderResponse.builder()
+                .menuFolderId(menuFolder.getId())
+                .menuFolderTitle(menuFolder.getTitle())
+                .menuFolderUrl(menuFolderImgUrl)
+                .menuFolderIcon(menuFolder.getIcon())
+                .menuIds(menuIds)
+                .index(menuFolder.getIndex())
+                .build();
+    }
+}


### PR DESCRIPTION
- 메뉴 총 갯수 추가

### ✏️ 작업 개요
- #74 

### ⛳ 작업 분류
- [x] 메뉴판 조회 API 수정

### 🔨 작업 상세 내용
1. 메뉴판 조회 API를 수정하였습니다.
2. 메뉴 총갯수 필드를 추가하였습니다.

### 💡 생각해볼 문제
- MenuFolderService에서 Menu에 대한 의존성이 필요해짐에 따라 MenuFolderService와 MenuService가 서로를 바라보게 되었습니다.
- MenuRepository를 추가하여 순환참조을 임시 해결하였지만 변경해야힙니다
