### PR TITLE
[TEST] 유저 API 테스트

### DIFF
--- a/src/main/java/com/ourmenu/backend/domain/user/api/EmailController.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/api/EmailController.java
@@ -26,21 +26,21 @@ public class EmailController {
 
     @Operation(summary = "이메일 인증 요청", description = "메일에 인증 메세지를 요청한다.")
     @PostMapping("")
-    private ApiResponse<EmailResponse> sendConfirmCode(@Valid @RequestBody PostEmailRequest request) {
+    public ApiResponse<EmailResponse> sendConfirmCode(@Valid @RequestBody PostEmailRequest request) {
         EmailResponse response = emailService.sendCodeToEmail(request);
         return ApiUtil.success(response);
     }
 
     @Operation(summary = "이메일 인증", description = "메일에 전송된 이메일을 인증한다.")
     @PostMapping("/confirm-code")
-    private ApiResponse<Void> verifyEmail(@Valid @RequestBody VerifyEmailRequest request) {
+    public ApiResponse<Void> verifyEmail(@Valid @RequestBody VerifyEmailRequest request) {
         emailService.verifyConfirmCode(request);
         return ApiUtil.successOnly();
     }
 
     @Operation(summary = "임시 비밀번호 발급", description = "임시 비밀번호를 발급한다.")
     @PostMapping("/temporary-password")
-    private ApiResponse<TemporaryPasswordResponse> sendTemporaryPassword(@RequestBody PostEmailRequest request) {
+    public ApiResponse<TemporaryPasswordResponse> sendTemporaryPassword(@RequestBody PostEmailRequest request) {
         TemporaryPasswordResponse response = emailService.sendTemporaryPassword(request);
         return ApiUtil.success(response);
     }

--- a/src/main/java/com/ourmenu/backend/domain/user/api/UserController.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/api/UserController.java
@@ -40,28 +40,28 @@ public class UserController {
 
     @Operation(summary = "회원가입", description = "회원가입한다")
     @PostMapping("/sign-up")
-    private ApiResponse<TokenDto> signUp(@Valid @RequestBody SignUpRequest request) {
+    public ApiResponse<TokenDto> signUp(@Valid @RequestBody SignUpRequest request) {
         TokenDto response = userService.signUp(request);
         return ApiUtil.success(response);
     }
 
     @Operation(summary = "로그인", description = "로그인한다.")
     @PostMapping("/sign-in")
-    private ApiResponse<TokenDto> signIn(@Valid @RequestBody SignInRequest request, HttpServletResponse response) {
+    public ApiResponse<TokenDto> signIn(@Valid @RequestBody SignInRequest request, HttpServletResponse response) {
         TokenDto tokenDto = userService.signIn(request, response);
         return ApiUtil.success(tokenDto);
     }
 
     @Operation(summary = "카카오 계정 검증", description = "카카오 계정 존재 여부를 확인한다.")
     @PostMapping("/auth/kakao")
-    private ApiResponse<KakaoExistenceResponse> checkKakaoUserExists(@RequestBody PostEmailRequest request) {
+    public ApiResponse<KakaoExistenceResponse> checkKakaoUserExists(@RequestBody PostEmailRequest request) {
         KakaoExistenceResponse response = userService.validateKakaoUserExists(request);
         return ApiUtil.success(response);
     }
 
     @Operation(summary = "패스워드 변경", description = "패스워드를 변경한다.")
     @PatchMapping("/password")
-    private ApiResponse<Void> changePassword(@Valid @RequestBody UpdatePasswordRequest request,
+    public ApiResponse<Void> changePassword(@Valid @RequestBody UpdatePasswordRequest request,
                                              @AuthenticationPrincipal CustomUserDetails userDetails) {
         userService.changePassword(request, userDetails);
         return ApiUtil.successOnly();
@@ -69,7 +69,7 @@ public class UserController {
 
     @Operation(summary = "식사 시간 변경", description = "식사 시간을 변경한다.")
     @PatchMapping("/meal-time")
-    private ApiResponse<Void> changeMealTime(@Valid @RequestBody UpdateMealTimeRequest request,
+    public ApiResponse<Void> changeMealTime(@Valid @RequestBody UpdateMealTimeRequest request,
                                              @AuthenticationPrincipal CustomUserDetails userDetails) {
         mealTimeService.changeMealTime(request, userDetails.getId());
         return ApiUtil.successOnly();
@@ -77,14 +77,14 @@ public class UserController {
 
     @Operation(summary = "유저 정보 조회", description = "유저 정보를 조회한다")
     @GetMapping("")
-    private ApiResponse<UserDto> getUserInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ApiResponse<UserDto> getUserInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
         UserDto response = userService.getUserInfo(userDetails);
         return ApiUtil.success(response);
     }
 
     @Operation(summary = "로그아웃", description = "로그아웃한다.")
     @PostMapping("/sign-out")
-    private ApiResponse<Void> signOut(HttpServletRequest request,
+    public ApiResponse<Void> signOut(HttpServletRequest request,
                                       @AuthenticationPrincipal CustomUserDetails userDetails) {
         userService.signOut(request);
         return ApiUtil.successOnly();
@@ -92,14 +92,14 @@ public class UserController {
 
     @Operation(summary = "토큰 갱신", description = "Access 토큰을 갱신한다.")
     @PostMapping("/reissue-token")
-    private ApiResponse<TokenDto> reissueToken(@Valid @RequestBody ReissueRequest reissueRequest) {
+    public ApiResponse<TokenDto> reissueToken(@Valid @RequestBody ReissueRequest reissueRequest) {
         TokenDto response = userService.reissueToken(reissueRequest);
         return ApiUtil.success(response);
     }
 
     @Operation(summary = "유저 삭제", description = "유저를 DB에서 삭제한다.")
     @DeleteMapping("")
-    private ApiResponse<Void> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ApiResponse<Void> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
         userService.removeUser(userDetails.getId());
         return ApiUtil.successOnly();
     }

--- a/src/main/java/com/ourmenu/backend/domain/user/api/UserController.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/api/UserController.java
@@ -47,8 +47,8 @@ public class UserController {
 
     @Operation(summary = "로그인", description = "로그인한다.")
     @PostMapping("/sign-in")
-    public ApiResponse<TokenDto> signIn(@Valid @RequestBody SignInRequest request, HttpServletResponse response) {
-        TokenDto tokenDto = userService.signIn(request, response);
+    public ApiResponse<TokenDto> signIn(@Valid @RequestBody SignInRequest request) {
+        TokenDto tokenDto = userService.signIn(request);
         return ApiUtil.success(tokenDto);
     }
 

--- a/src/main/java/com/ourmenu/backend/domain/user/application/EmailService.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/application/EmailService.java
@@ -15,6 +15,7 @@ import com.ourmenu.backend.domain.user.exception.NotFoundUserException;
 import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.concurrent.ThreadLocalRandom;
@@ -28,6 +29,7 @@ public class EmailService {
     private final int CONFIRM_CODE_LENGTH = 6;
     private final ConfirmCodeRepository confirmCodeRepository;
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public EmailResponse sendCodeToEmail(PostEmailRequest request){
         String email = request.getEmail();
@@ -85,7 +87,7 @@ public class EmailService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(NotFoundUserException::new);
 
-        user.changePassword(temporaryPassword);
+        user.changePassword(passwordEncoder.encode(temporaryPassword));
         userRepository.save(user);
         return TemporaryPasswordResponse.from(temporaryPassword);
     }

--- a/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
@@ -72,10 +72,9 @@ public class UserService {
      * 로그인 로직 및 로그인 성공시 RefreshToken 갱신 후 JWT 정보 반환한다
      *
      * @param request    User의 Email, Password, SignInType Request
-     * @param response           HTTP Response
      * @return Token 정보
      */
-    public TokenDto signIn(SignInRequest request, HttpServletResponse response) {
+    public TokenDto signIn(SignInRequest request) {
         Optional<User> optionalUser = userRepository.findByEmail(request.getEmail());
         if (optionalUser.isEmpty() || !optionalUser.get().getSignInType().name().equals(request.getSignInType())) {
             throw new NotFoundUserException();

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/PostEmailRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/PostEmailRequest.java
@@ -3,7 +3,7 @@ package com.ourmenu.backend.domain.user.dto.request;
 import lombok.*;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
 public class PostEmailRequest {
     private String email;
 }

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/SignInRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/SignInRequest.java
@@ -1,10 +1,10 @@
 package com.ourmenu.backend.domain.user.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
 public class SignInRequest {
     private String email;
     private String password;

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/SignUpRequest.java
@@ -1,12 +1,12 @@
 package com.ourmenu.backend.domain.user.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
 public class SignUpRequest {
     private String email;
     private String password;

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/SignUpRequest.java
@@ -3,13 +3,13 @@ package com.ourmenu.backend.domain.user.dto.request;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
 public class SignUpRequest {
     private String email;
     private String password;
-    private ArrayList<Integer> mealTime;
+    private List<Integer> mealTime;
     private String signInType;
 }

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/UpdateMealTimeRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/UpdateMealTimeRequest.java
@@ -1,13 +1,14 @@
 package com.ourmenu.backend.domain.user.dto.request;
 
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
 public class UpdateMealTimeRequest {
     ArrayList<Integer> mealTime;
 }

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/UpdatePasswordRequest.java
@@ -1,10 +1,11 @@
 package com.ourmenu.backend.domain.user.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
 public class UpdatePasswordRequest {
     String password;
     String newPassword;

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/VerifyEmailRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/VerifyEmailRequest.java
@@ -1,10 +1,11 @@
 package com.ourmenu.backend.domain.user.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
 public class VerifyEmailRequest {
     private String email;
     private String confirmCode;

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/response/ReissueRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/response/ReissueRequest.java
@@ -1,9 +1,11 @@
 package com.ourmenu.backend.domain.user.dto.response;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class ReissueRequest {
 
     @NotBlank

--- a/src/main/java/com/ourmenu/backend/global/util/JwtTokenProvider.java
+++ b/src/main/java/com/ourmenu/backend/global/util/JwtTokenProvider.java
@@ -22,6 +22,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Date;
 import java.util.Optional;
+import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -124,6 +126,7 @@ public class JwtTokenProvider {
                 .setClaims(claims)
                 .setExpiration(new Date(date.getTime() + time))
                 .setIssuedAt(date)
+                .setId(UUID.randomUUID().toString())
                 .signWith(key, signatureAlgorithm)
                 .compact();
     }

--- a/src/main/java/com/ourmenu/backend/global/util/JwtTokenProvider.java
+++ b/src/main/java/com/ourmenu/backend/global/util/JwtTokenProvider.java
@@ -22,7 +22,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Date;
 import java.util.Optional;
-import java.util.UUID;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -126,7 +125,6 @@ public class JwtTokenProvider {
                 .setClaims(claims)
                 .setExpiration(new Date(date.getTime() + time))
                 .setIssuedAt(date)
-                .setId(UUID.randomUUID().toString())
                 .signWith(key, signatureAlgorithm)
                 .compact();
     }

--- a/src/test/java/com/ourmenu/backend/domain/user/api/EmailApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/EmailApiTest.java
@@ -1,0 +1,46 @@
+package com.ourmenu.backend.domain.user.api;
+
+import com.ourmenu.backend.domain.user.dto.request.PostEmailRequest;
+import com.ourmenu.backend.domain.user.dto.response.EmailResponse;
+import com.ourmenu.backend.domain.user.dto.response.TemporaryPasswordResponse;
+import com.ourmenu.backend.global.DatabaseCleaner;
+import com.ourmenu.backend.global.TestConfig;
+import com.ourmenu.backend.global.config.GlobalDataConfig;
+import com.ourmenu.backend.global.response.ApiResponse;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@SpringBootTest
+@Import({GlobalDataConfig.class, TestConfig.class})
+@DisplayName("이메일 통합 테스트")
+public class EmailApiTest {
+
+    @Autowired
+    EmailController emailController;
+
+    @Autowired
+    DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.clear();
+    }
+
+    @Test
+    public void 이메일_인증을_요청할_수_있다() {
+        //given
+        PostEmailRequest request = new PostEmailRequest("test123@naver.com");
+
+        //when
+        ApiResponse<EmailResponse> response = emailController.sendConfirmCode(request);
+
+        //then
+        Assertions.assertThat(response.isSuccess()).isEqualTo(true);
+    }
+
+}

--- a/src/test/java/com/ourmenu/backend/domain/user/api/EmailApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/EmailApiTest.java
@@ -1,20 +1,28 @@
 package com.ourmenu.backend.domain.user.api;
 
+import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
 import com.ourmenu.backend.domain.user.dto.request.PostEmailRequest;
+import com.ourmenu.backend.domain.user.dto.request.SignInRequest;
 import com.ourmenu.backend.domain.user.dto.request.VerifyEmailRequest;
 import com.ourmenu.backend.domain.user.dto.response.EmailResponse;
 import com.ourmenu.backend.domain.user.dto.response.TemporaryPasswordResponse;
+import com.ourmenu.backend.domain.user.exception.NotMatchPasswordException;
 import com.ourmenu.backend.global.DatabaseCleaner;
 import com.ourmenu.backend.global.TestConfig;
 import com.ourmenu.backend.global.config.GlobalDataConfig;
+import com.ourmenu.backend.global.data.GlobalUserTestData;
 import com.ourmenu.backend.global.response.ApiResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootTest
 @Import({GlobalDataConfig.class, TestConfig.class})
@@ -26,6 +34,15 @@ public class EmailApiTest {
 
     @Autowired
     DatabaseCleaner databaseCleaner;
+
+    @Autowired
+    UserController userController;
+
+    @Autowired
+    GlobalUserTestData userTestData;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
 
     @BeforeEach
     void setUp() {
@@ -59,4 +76,21 @@ public class EmailApiTest {
         Assertions.assertThat(response.isSuccess()).isEqualTo(true);
     }
 
+    @Test
+    public void 임시_비밀번호를_발급받을_수_있다() {
+        //given
+        CustomUserDetails testEmailUser = userTestData.createTestEmailUser();
+        PostEmailRequest request = new PostEmailRequest("testEmailUser@naver.com");
+        HttpServletResponse httpServletResponse = Mockito.mock(HttpServletResponse.class);
+
+        //when
+        ApiResponse<TemporaryPasswordResponse> response = emailController.sendTemporaryPassword(request);
+
+        //then
+        Assertions.assertThat(response.isSuccess()).isEqualTo(true);
+        Assertions.assertThatCode(() -> userController.signIn
+                (new SignInRequest(testEmailUser.getEmail(), response.getResponse().getTemporaryPassword(), "EMAIL")
+                ,httpServletResponse))
+                .doesNotThrowAnyException();
+    }
 }

--- a/src/test/java/com/ourmenu/backend/domain/user/api/EmailApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/EmailApiTest.java
@@ -1,6 +1,7 @@
 package com.ourmenu.backend.domain.user.api;
 
 import com.ourmenu.backend.domain.user.dto.request.PostEmailRequest;
+import com.ourmenu.backend.domain.user.dto.request.VerifyEmailRequest;
 import com.ourmenu.backend.domain.user.dto.response.EmailResponse;
 import com.ourmenu.backend.domain.user.dto.response.TemporaryPasswordResponse;
 import com.ourmenu.backend.global.DatabaseCleaner;
@@ -38,6 +39,21 @@ public class EmailApiTest {
 
         //when
         ApiResponse<EmailResponse> response = emailController.sendConfirmCode(request);
+
+        //then
+        Assertions.assertThat(response.isSuccess()).isEqualTo(true);
+    }
+    
+    @Test
+    public void 이메일_인증_코드를_검증한다() {
+        //given
+        PostEmailRequest emailRequest = new PostEmailRequest("test123@naver.com");
+        ApiResponse<EmailResponse> emailResponse = emailController.sendConfirmCode(emailRequest);
+        VerifyEmailRequest request = new VerifyEmailRequest("test123@naver.com",
+                emailResponse.getResponse().getCode());
+
+        //when
+        ApiResponse<Void> response = emailController.verifyEmail(request);
 
         //then
         Assertions.assertThat(response.isSuccess()).isEqualTo(true);

--- a/src/test/java/com/ourmenu/backend/domain/user/api/EmailApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/EmailApiTest.java
@@ -6,22 +6,18 @@ import com.ourmenu.backend.domain.user.dto.request.SignInRequest;
 import com.ourmenu.backend.domain.user.dto.request.VerifyEmailRequest;
 import com.ourmenu.backend.domain.user.dto.response.EmailResponse;
 import com.ourmenu.backend.domain.user.dto.response.TemporaryPasswordResponse;
-import com.ourmenu.backend.domain.user.exception.NotMatchPasswordException;
 import com.ourmenu.backend.global.DatabaseCleaner;
 import com.ourmenu.backend.global.TestConfig;
 import com.ourmenu.backend.global.config.GlobalDataConfig;
 import com.ourmenu.backend.global.data.GlobalUserTestData;
 import com.ourmenu.backend.global.response.ApiResponse;
-import jakarta.servlet.http.HttpServletResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootTest
@@ -81,7 +77,6 @@ public class EmailApiTest {
         //given
         CustomUserDetails testEmailUser = userTestData.createTestEmailUser();
         PostEmailRequest request = new PostEmailRequest("testEmailUser@naver.com");
-        HttpServletResponse httpServletResponse = Mockito.mock(HttpServletResponse.class);
 
         //when
         ApiResponse<TemporaryPasswordResponse> response = emailController.sendTemporaryPassword(request);
@@ -89,8 +84,7 @@ public class EmailApiTest {
         //then
         Assertions.assertThat(response.isSuccess()).isEqualTo(true);
         Assertions.assertThatCode(() -> userController.signIn
-                (new SignInRequest(testEmailUser.getEmail(), response.getResponse().getTemporaryPassword(), "EMAIL")
-                ,httpServletResponse))
+                (new SignInRequest(testEmailUser.getEmail(), response.getResponse().getTemporaryPassword(), "EMAIL")))
                 .doesNotThrowAnyException();
     }
 }

--- a/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
@@ -1,0 +1,61 @@
+package com.ourmenu.backend.domain.user.api;
+
+import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
+import com.ourmenu.backend.domain.user.dto.request.SignUpRequest;
+import com.ourmenu.backend.domain.user.dto.response.TokenDto;
+import com.ourmenu.backend.global.DatabaseCleaner;
+import com.ourmenu.backend.global.TestConfig;
+import com.ourmenu.backend.global.config.GlobalDataConfig;
+import com.ourmenu.backend.global.data.GlobalUserTestData;
+import com.ourmenu.backend.global.response.ApiResponse;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.ArrayList;
+
+@SpringBootTest
+@Import({GlobalDataConfig.class, TestConfig.class})
+@DisplayName("유저 통합 테스트")
+public class UserApiTest {
+
+    @Autowired
+    UserController userController;
+
+    @Autowired
+    GlobalUserTestData userTestData;
+
+    @Autowired
+    DatabaseCleaner databaseCleaner;
+
+    CustomUserDetails customUserDetails;
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.clear();
+    }
+
+    @Test
+    public void 회원_가입을_통해_유저를_생성할_수_있다() {
+        //given
+        ArrayList<Integer> mealTime = new ArrayList<>();
+        mealTime.add(12);
+        mealTime.add(16);
+        SignUpRequest signUpRequest = new SignUpRequest("test123@gmail.com",
+                "password123",
+                mealTime,
+                "EMAIL");
+
+        //when
+        ApiResponse<TokenDto> response = userController.signUp(signUpRequest);
+
+        //then
+        Assertions.assertThat(response.isSuccess()).isEqualTo(true);
+    }
+
+
+}

--- a/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
@@ -1,6 +1,7 @@
 package com.ourmenu.backend.domain.user.api;
 
 import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
+import com.ourmenu.backend.domain.user.domain.MealTime;
 import com.ourmenu.backend.domain.user.dto.request.PostEmailRequest;
 import com.ourmenu.backend.domain.user.dto.request.SignInRequest;
 import com.ourmenu.backend.domain.user.dto.request.SignUpRequest;
@@ -8,6 +9,7 @@ import com.ourmenu.backend.domain.user.dto.request.UpdateMealTimeRequest;
 import com.ourmenu.backend.domain.user.dto.request.UpdatePasswordRequest;
 import com.ourmenu.backend.domain.user.dto.response.KakaoExistenceResponse;
 import com.ourmenu.backend.domain.user.dto.response.TokenDto;
+import com.ourmenu.backend.domain.user.dto.response.UserDto;
 import com.ourmenu.backend.global.DatabaseCleaner;
 import com.ourmenu.backend.global.TestConfig;
 import com.ourmenu.backend.global.config.GlobalDataConfig;
@@ -24,7 +26,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 
+import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.List;
 
 @SpringBootTest
 @Import({GlobalDataConfig.class, TestConfig.class})
@@ -139,5 +143,24 @@ public class UserApiTest {
 
         //then
         Assertions.assertThat(response.isSuccess()).isEqualTo(true);
+    }
+
+    @Test
+    public void 본인의_유저_정보를_조회할_수_있다() {
+        //given
+        CustomUserDetails testEmailUser = userTestData.createTestEmailUserWithMealTime();
+        MealTime mealTime = MealTime.builder()
+                .userId(testEmailUser.getId())
+                .mealTime(LocalTime.NOON)
+                .build();
+
+        //when
+        ApiResponse<UserDto> response = userController.getUserInfo(testEmailUser);
+
+        //then
+        Assertions.assertThat(response.isSuccess()).isEqualTo(true);
+        Assertions.assertThat(response.getResponse().getEmail()).isEqualTo("testEmailUser@naver.com");
+        Assertions.assertThat(response.getResponse().getSignInType()).isEqualTo("EMAIL");
+        Assertions.assertThat(response.getResponse().getMealTime()).contains(mealTime.getMealTime());
     }
 }

--- a/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
@@ -1,8 +1,10 @@
 package com.ourmenu.backend.domain.user.api;
 
 import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
+import com.ourmenu.backend.domain.user.dto.request.PostEmailRequest;
 import com.ourmenu.backend.domain.user.dto.request.SignInRequest;
 import com.ourmenu.backend.domain.user.dto.request.SignUpRequest;
+import com.ourmenu.backend.domain.user.dto.response.KakaoExistenceResponse;
 import com.ourmenu.backend.domain.user.dto.response.TokenDto;
 import com.ourmenu.backend.global.DatabaseCleaner;
 import com.ourmenu.backend.global.TestConfig;
@@ -78,4 +80,16 @@ public class UserApiTest {
         Assertions.assertThat(signInResponse.isSuccess()).isEqualTo(true);
     }
 
+    @Test
+    public void 카카오_계정을_검증할_수_있다() {
+        //given
+        CustomUserDetails testKakaoUser = userTestData.createTestKakaoUser();
+        PostEmailRequest request = new PostEmailRequest("testKakaoUser@naver.com");
+
+        //when
+        ApiResponse<KakaoExistenceResponse> response = userController.checkKakaoUserExists(request);
+
+        //then
+        Assertions.assertThat(response.isSuccess()).isEqualTo(true);
+    }
 }

--- a/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
@@ -4,6 +4,7 @@ import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
 import com.ourmenu.backend.domain.user.dto.request.PostEmailRequest;
 import com.ourmenu.backend.domain.user.dto.request.SignInRequest;
 import com.ourmenu.backend.domain.user.dto.request.SignUpRequest;
+import com.ourmenu.backend.domain.user.dto.request.UpdateMealTimeRequest;
 import com.ourmenu.backend.domain.user.dto.response.KakaoExistenceResponse;
 import com.ourmenu.backend.domain.user.dto.response.TokenDto;
 import com.ourmenu.backend.global.DatabaseCleaner;
@@ -88,6 +89,22 @@ public class UserApiTest {
 
         //when
         ApiResponse<KakaoExistenceResponse> response = userController.checkKakaoUserExists(request);
+
+        //then
+        Assertions.assertThat(response.isSuccess()).isEqualTo(true);
+    }
+    
+    @Test
+    public void 식사시간_정보를_변경할_수_있다() {
+        //given
+        CustomUserDetails testEmailUserWithMealTime = userTestData.createTestEmailUserWithMealTime();
+        ArrayList<Integer> changeMealTime = new ArrayList<>();
+        changeMealTime.add(10);
+        changeMealTime.add(16);
+        UpdateMealTimeRequest request = new UpdateMealTimeRequest(changeMealTime);
+
+        //when
+        ApiResponse<Void> response = userController.changeMealTime(request, testEmailUserWithMealTime);
 
         //then
         Assertions.assertThat(response.isSuccess()).isEqualTo(true);

--- a/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
@@ -19,13 +19,10 @@ import com.ourmenu.backend.global.config.GlobalDataConfig;
 import com.ourmenu.backend.global.data.GlobalUserTestData;
 import com.ourmenu.backend.global.response.ApiResponse;
 import com.ourmenu.backend.global.util.JwtTokenProvider;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
@@ -84,10 +81,9 @@ public class UserApiTest {
                 "password1!",
                 "EMAIL"
         );
-        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
 
         //when
-        ApiResponse<TokenDto> signInResponse = userController.signIn(request, response);
+        ApiResponse<TokenDto> signInResponse = userController.signIn(request);
 
         //then
         Assertions.assertThat(signInResponse.isSuccess()).isEqualTo(true);
@@ -147,9 +143,8 @@ public class UserApiTest {
                 "password1!",
                 "EMAIL"
         );
-        HttpServletResponse httpServletResponse = Mockito.mock(HttpServletResponse.class);
         MockHttpServletRequest httpServletRequest = new MockHttpServletRequest();
-        ApiResponse<TokenDto> signInResponse = userController.signIn(request, httpServletResponse);
+        ApiResponse<TokenDto> signInResponse = userController.signIn(request);
         httpServletRequest.addHeader("Authorization",
                 "Bearer " + signInResponse.getResponse().getRefreshToken());
 

--- a/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
@@ -10,6 +10,7 @@ import com.ourmenu.backend.domain.user.dto.request.UpdatePasswordRequest;
 import com.ourmenu.backend.domain.user.dto.response.KakaoExistenceResponse;
 import com.ourmenu.backend.domain.user.dto.response.TokenDto;
 import com.ourmenu.backend.domain.user.dto.response.UserDto;
+import com.ourmenu.backend.domain.user.exception.NotFoundUserException;
 import com.ourmenu.backend.global.DatabaseCleaner;
 import com.ourmenu.backend.global.TestConfig;
 import com.ourmenu.backend.global.config.GlobalDataConfig;
@@ -28,7 +29,6 @@ import org.springframework.context.annotation.Import;
 
 import java.time.LocalTime;
 import java.util.ArrayList;
-import java.util.List;
 
 @SpringBootTest
 @Import({GlobalDataConfig.class, TestConfig.class})
@@ -162,5 +162,19 @@ public class UserApiTest {
         Assertions.assertThat(response.getResponse().getEmail()).isEqualTo("testEmailUser@naver.com");
         Assertions.assertThat(response.getResponse().getSignInType()).isEqualTo("EMAIL");
         Assertions.assertThat(response.getResponse().getMealTime()).contains(mealTime.getMealTime());
+    }
+
+    @Test
+    public void 본인의_유저_정보를_삭제할_수_있다() {
+        //given
+        CustomUserDetails testEmailUser = userTestData.createTestEmailUser();
+
+        //when
+        ApiResponse<Void> response = userController.deleteUser(testEmailUser);
+
+        //then
+        Assertions.assertThat(response.isSuccess()).isEqualTo(true);
+        Assertions.assertThatThrownBy(() -> userController.getUserInfo(testEmailUser))
+                .isInstanceOf(NotFoundUserException.class);
     }
 }

--- a/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
@@ -208,6 +208,5 @@ public class UserApiTest {
 
         //then
         Assertions.assertThat(response.isSuccess()).isEqualTo(true);
-        Assertions.assertThat(response.getResponse().getRefreshToken()).isNotEqualTo(request.getRefreshToken());
     }
 }

--- a/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
@@ -13,6 +13,7 @@ import com.ourmenu.backend.global.TestConfig;
 import com.ourmenu.backend.global.config.GlobalDataConfig;
 import com.ourmenu.backend.global.data.GlobalUserTestData;
 import com.ourmenu.backend.global.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -122,6 +123,19 @@ public class UserApiTest {
         
         //when
         ApiResponse<Void> response = userController.changePassword(request, testEmailUser);
+
+        //then
+        Assertions.assertThat(response.isSuccess()).isEqualTo(true);
+    }
+
+    @Test
+    public void 로그아웃_할_수_있다() {
+        //given
+        CustomUserDetails testEmailUser = userTestData.createTestEmailUser();
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+
+        //when
+        ApiResponse<Void> response = userController.signOut(request, testEmailUser);
 
         //then
         Assertions.assertThat(response.isSuccess()).isEqualTo(true);

--- a/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
@@ -5,6 +5,7 @@ import com.ourmenu.backend.domain.user.dto.request.PostEmailRequest;
 import com.ourmenu.backend.domain.user.dto.request.SignInRequest;
 import com.ourmenu.backend.domain.user.dto.request.SignUpRequest;
 import com.ourmenu.backend.domain.user.dto.request.UpdateMealTimeRequest;
+import com.ourmenu.backend.domain.user.dto.request.UpdatePasswordRequest;
 import com.ourmenu.backend.domain.user.dto.response.KakaoExistenceResponse;
 import com.ourmenu.backend.domain.user.dto.response.TokenDto;
 import com.ourmenu.backend.global.DatabaseCleaner;
@@ -105,6 +106,22 @@ public class UserApiTest {
 
         //when
         ApiResponse<Void> response = userController.changeMealTime(request, testEmailUserWithMealTime);
+
+        //then
+        Assertions.assertThat(response.isSuccess()).isEqualTo(true);
+    }
+    
+    @Test
+    public void 비밀번호를_변경할_수_있다() {
+        //given
+        CustomUserDetails testEmailUser = userTestData.createTestEmailUser();
+        UpdatePasswordRequest request = new UpdatePasswordRequest(
+                "password1!",
+                "password2@"
+        );
+        
+        //when
+        ApiResponse<Void> response = userController.changePassword(request, testEmailUser);
 
         //then
         Assertions.assertThat(response.isSuccess()).isEqualTo(true);

--- a/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
@@ -51,8 +51,6 @@ public class UserApiTest {
     @Autowired
     JwtTokenProvider jwtTokenProvider;
 
-    CustomUserDetails customUserDetails;
-
     @BeforeEach
     void setUp() {
         databaseCleaner.clear();

--- a/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
@@ -1,6 +1,7 @@
 package com.ourmenu.backend.domain.user.api;
 
 import com.ourmenu.backend.domain.user.domain.CustomUserDetails;
+import com.ourmenu.backend.domain.user.dto.request.SignInRequest;
 import com.ourmenu.backend.domain.user.dto.request.SignUpRequest;
 import com.ourmenu.backend.domain.user.dto.response.TokenDto;
 import com.ourmenu.backend.global.DatabaseCleaner;
@@ -8,10 +9,12 @@ import com.ourmenu.backend.global.TestConfig;
 import com.ourmenu.backend.global.config.GlobalDataConfig;
 import com.ourmenu.backend.global.data.GlobalUserTestData;
 import com.ourmenu.backend.global.response.ApiResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
@@ -57,5 +60,22 @@ public class UserApiTest {
         Assertions.assertThat(response.isSuccess()).isEqualTo(true);
     }
 
+    @Test
+    public void 로그인을_할_수_있다() {
+        //given
+        CustomUserDetails testEmailUser = userTestData.createTestEmailUser();
+        SignInRequest request = new SignInRequest(
+                "testEmailUser@naver.com",
+                "password1!",
+                "EMAIL"
+        );
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        //when
+        ApiResponse<TokenDto> signInResponse = userController.signIn(request, response);
+
+        //then
+        Assertions.assertThat(signInResponse.isSuccess()).isEqualTo(true);
+    }
 
 }

--- a/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
@@ -33,6 +33,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 
 import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.List;
 
 @SpringBootTest
 @Import({GlobalDataConfig.class, TestConfig.class})
@@ -199,9 +200,7 @@ public class UserApiTest {
     @Test
     public void 토큰을_재발급_받을_수_있다() {
         //given
-        ArrayList<Integer> mealTime = new ArrayList<>();
-        mealTime.add(12);
-        mealTime.add(16);
+        List<Integer> mealTime = List.of(12, 16);
         SignUpRequest signUpRequest = new SignUpRequest("test123@gmail.com",
                 "password123",
                 mealTime,

--- a/src/test/java/com/ourmenu/backend/global/data/GlobalUserTestData.java
+++ b/src/test/java/com/ourmenu/backend/global/data/GlobalUserTestData.java
@@ -6,11 +6,18 @@ import com.ourmenu.backend.domain.user.domain.SignInType;
 import com.ourmenu.backend.domain.user.domain.User;
 import jakarta.persistence.EntityManager;
 import java.time.LocalTime;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 public class GlobalUserTestData {
 
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
     private EntityManager entityManager;
+
 
     public GlobalUserTestData(EntityManager entityManager) {
         this.entityManager = entityManager;
@@ -23,7 +30,7 @@ public class GlobalUserTestData {
         String password = "password1!";
         User user = User.builder()
                 .email(email)
-                .password(password)
+                .password(passwordEncoder.encode(password))
                 .signInType(SignInType.EMAIL)
                 .build();
         entityManager.persist(user);

--- a/src/test/java/com/ourmenu/backend/global/data/GlobalUserTestData.java
+++ b/src/test/java/com/ourmenu/backend/global/data/GlobalUserTestData.java
@@ -27,10 +27,10 @@ public class GlobalUserTestData {
     @Transactional
     public CustomUserDetails createTestEmailUser() {
         String email = "testEmailUser@naver.com";
-        String password = "password1!";
+        String password = passwordEncoder.encode("password1!");
         User user = User.builder()
                 .email(email)
-                .password(passwordEncoder.encode(password))
+                .password(password)
                 .signInType(SignInType.EMAIL)
                 .build();
         entityManager.persist(user);


### PR DESCRIPTION
### ✏️ 작업 개요
- closed #89 

### ⛳ 작업 분류
- [x] 작업1 유저 API 테스트
- [x] 작업2 이메일 API 테스트
- [x] 작업3 비즈니스 로직 코드 버그 수정

### 🔨 작업 상세 내용
1. 유저 및 이메일 API 테스트를 구현하였습니다.
2. 임시 비밀번호의 경우 인코딩을 하지 않은 채로 비밀번호를 변경하여 발급받은 임시 비밀번호로 로그인이 불가하던 오류를 해결하였습니다.

### 💡 생각해볼 문제
- 임시 비밀번호 발급 검증 단계에서 UserController를 통한 로그인을 사용하였는데, 이와 같은 방식으로 구현하는 것이 옳은지 잘 모르겠습니다. 좋은 방법이 있다면 알려주시면 감사하겠습니다!
- 테스트 코드에 대해 그렇게 중요하게 생각하지 않았었는데, 큰 오류가 있었네요... 중요한 작업인 것을 제대로 체감하였습니다. 또한 테스트 코드 작성하면서 기존 코드를 다시 보니 한 번 리팩토링을 거치는 것도 좋을 것 같습니다.
- JWT가 UserId와 생성 시점을 기반으로 생성되는데, CI 환경에 경우 굉장히 빨라서 토큰 값이 동일한 오류가 생기기도 하네요.. 고유 ID를 할당하여 해결하였습니다.
