### PR TITLE
[FIX] 마이페이지 API 수정

### DIFF
--- a/src/main/java/com/ourmenu/backend/domain/user/application/EmailService.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/application/EmailService.java
@@ -57,7 +57,7 @@ public class EmailService {
     }
 
     public String generateRandomCode(int length) {
-        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        String characters = "0123456789";
         StringBuilder confirmCode = new StringBuilder();
         ThreadLocalRandom random = ThreadLocalRandom.current();
 

--- a/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
@@ -12,6 +12,7 @@ import com.ourmenu.backend.domain.user.dto.request.SignInRequest;
 import com.ourmenu.backend.domain.user.dto.request.SignUpRequest;
 import com.ourmenu.backend.domain.user.dto.request.UpdatePasswordRequest;
 import com.ourmenu.backend.domain.user.dto.response.KakaoExistenceResponse;
+import com.ourmenu.backend.domain.user.dto.response.MealTimeDto;
 import com.ourmenu.backend.domain.user.dto.response.ReissueRequest;
 import com.ourmenu.backend.domain.user.dto.response.TokenDto;
 import com.ourmenu.backend.domain.user.dto.response.UserDto;
@@ -23,10 +24,14 @@ import com.ourmenu.backend.domain.user.exception.NotMatchPasswordException;
 import com.ourmenu.backend.domain.user.exception.NotMatchTokenException;
 import com.ourmenu.backend.domain.user.exception.TokenExpiredExcpetion;
 import com.ourmenu.backend.domain.user.exception.UnsupportedSignInTypeException;
+import com.ourmenu.backend.domain.user.util.TimeUtil;
 import com.ourmenu.backend.global.util.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -132,8 +137,15 @@ public class UserService {
                 .orElseThrow(NotFoundUserException::new);
 
         List<MealTime> mealTimes = mealTimeService.findAllByUserId(userDetails.getId());
+        List<MealTimeDto> mealTimeDtoList = new ArrayList<>();
 
-        return UserDto.of(user, mealTimes);
+        for (MealTime mealTime : mealTimes) {
+            boolean isAfter = LocalTime.now().isAfter(mealTime.getMealTime());
+            MealTimeDto mealTimeDto = MealTimeDto.of(mealTime, isAfter);
+            mealTimeDtoList.add(mealTimeDto);
+        }
+
+        return UserDto.of(user, mealTimeDtoList);
     }
 
     /**

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/PostEmailRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/PostEmailRequest.java
@@ -3,6 +3,7 @@ package com.ourmenu.backend.domain.user.dto.request;
 import lombok.*;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class PostEmailRequest {
     private String email;

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/SignInRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/SignInRequest.java
@@ -1,9 +1,12 @@
 package com.ourmenu.backend.domain.user.dto.request;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class SignInRequest {
     private String email;

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/SignUpRequest.java
@@ -1,11 +1,14 @@
 package com.ourmenu.backend.domain.user.dto.request;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class SignUpRequest {
     private String email;

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/UpdateMealTimeRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/UpdateMealTimeRequest.java
@@ -1,14 +1,16 @@
 package com.ourmenu.backend.domain.user.dto.request;
 
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
+import java.util.List;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class UpdateMealTimeRequest {
-    ArrayList<Integer> mealTime;
+    List<Integer> mealTime;
 }

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/UpdatePasswordRequest.java
@@ -1,10 +1,12 @@
 package com.ourmenu.backend.domain.user.dto.request;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class UpdatePasswordRequest {
     String password;

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/request/VerifyEmailRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/request/VerifyEmailRequest.java
@@ -1,10 +1,12 @@
 package com.ourmenu.backend.domain.user.dto.request;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class VerifyEmailRequest {
     private String email;

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/response/MealTimeDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/response/MealTimeDto.java
@@ -1,0 +1,26 @@
+package com.ourmenu.backend.domain.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ourmenu.backend.domain.user.domain.MealTime;
+import com.ourmenu.backend.domain.user.util.TimeUtil;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonIgnoreProperties({"after"})
+public class MealTimeDto {
+
+    private Integer mealTime;
+
+    @JsonProperty("isAfter")
+    private boolean isAfter;
+
+    public static MealTimeDto of(MealTime mealTime, boolean isAfter) {
+        return MealTimeDto.builder()
+                .mealTime(TimeUtil.toInteger(mealTime.getMealTime()))
+                .isAfter(isAfter)
+                .build();
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/response/UserDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/response/UserDto.java
@@ -2,9 +2,10 @@ package com.ourmenu.backend.domain.user.dto.response;
 
 import com.ourmenu.backend.domain.user.domain.MealTime;
 import com.ourmenu.backend.domain.user.domain.User;
-import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import com.ourmenu.backend.domain.user.util.TimeUtil;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,15 +15,13 @@ public class UserDto {
 
     private String email;
     private String signInType;
-    private List<LocalTime> mealTime;
+    private List<MealTimeDto> mealTimeList;
 
-    public static UserDto of(User user, List<MealTime> mealTimes) {
+    public static UserDto of(User user, List<MealTimeDto> mealTimes) {
         return UserDto.builder()
                 .email(user.getEmail())
                 .signInType(user.getSignInType().name())
-                .mealTime(mealTimes.stream()
-                        .map(MealTime::getMealTime)
-                        .collect(Collectors.toList()))
+                .mealTimeList(mealTimes)
                 .build();
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/response/UserDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/response/UserDto.java
@@ -1,11 +1,8 @@
 package com.ourmenu.backend.domain.user.dto.response;
 
-import com.ourmenu.backend.domain.user.domain.MealTime;
 import com.ourmenu.backend.domain.user.domain.User;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import com.ourmenu.backend.domain.user.util.TimeUtil;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,12 +13,18 @@ public class UserDto {
     private String email;
     private String signInType;
     private List<MealTimeDto> mealTimeList;
+    private String announcementUrl;
+    private String customerServiceUrl;
+    private String appReviewUrl;
 
     public static UserDto of(User user, List<MealTimeDto> mealTimes) {
         return UserDto.builder()
                 .email(user.getEmail())
                 .signInType(user.getSignInType().name())
                 .mealTimeList(mealTimes)
+                .announcementUrl("")
+                .customerServiceUrl("")
+                .appReviewUrl("")
                 .build();
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/user/util/TimeUtil.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/util/TimeUtil.java
@@ -75,4 +75,15 @@ public class TimeUtil {
 
         return todayDuration.toMinutes() + tomorrowDuration.toMinutes();
     }
+
+    /**
+     * LocalTime(HH:mm:ss) 을 Integer(HHmm) 형식으로 변경한다.
+     *
+     * @param time
+     * @return
+     */
+    public static int toInteger(LocalTime time) {
+        String timeStr = String.format("%02d%02d", time.getHour(), time.getMinute());
+        return Integer.parseInt(timeStr);
+    }
 }


### PR DESCRIPTION
### ✏️ 작업 개요
- #94 

### ⛳ 작업 분류
- [ ] 작업1 Request NoArgsConstructor 추가
- [ ] 작업2 마이페이지 식사시간 여부 반영 및 공지사항, 고객센터, 앱 리뷰 필드 추가
- [ ] 작업3 랜덤코드 영문자 제외

### 🔨 작업 상세 내용
1. 테스트 코드를 작성하며 제거했던 NoArgsContructor를 Private으로 추가해두었습니다.
2. 마이페이지 환경이 변경되며 추가적으로 필요해진 필드인 식사시간 여부에 대해 구현하였고 공지사항, 고객센터 및 앱 리뷰 URL은 클라이언트의 요청에 따라 우선 빈 문자열로 보내주고 있습니다.
3. 클라이언트의 요청에 따라 랜덤코드의 영문자를 제거하였습니다.

### 💡 생각해볼 문제
- 배포된 환경의 Swagger는 정상적으로 동작하는 것 같은데, 로컬 환경의 Swagger에서는 Request의 success 필드가 추가되어 반환되고 있습니다. (다른 프로젝트에서도 이런 것 같은데 로컬 문제인 것 같기도 합니다.)
- 로그아웃 API와 관련하여 약간 문제가 있는 것 같아 수정해야 할 것 같습니다.
