### PR TITLE
[FIX] ENUM -> URL 변경

### DIFF
--- a/src/main/java/com/ourmenu/backend/domain/cache/application/CacheService.java
+++ b/src/main/java/com/ourmenu/backend/domain/cache/application/CacheService.java
@@ -44,7 +44,7 @@ public class CacheService {
                 .map(menuPin -> {
                     String menuPinMapUrl = urlConvertor.getMenuPinMapUrl(menuPin);
                     String menuPinAddUrl = urlConvertor.getMenuPinAddUrl(menuPin);
-                    String menuPinMapAddDiable = urlConvertor.getMenuPinMapAddDiable(menuPin);
+                    String menuPinMapAddDiable = urlConvertor.getMenuPinMapAddDisable(menuPin);
                     return SimpleMenuPinResponse.of(menuPin, menuPinMapUrl, menuPinAddUrl,
                             menuPinMapAddDiable);
                 })

--- a/src/main/java/com/ourmenu/backend/domain/cache/application/CacheService.java
+++ b/src/main/java/com/ourmenu/backend/domain/cache/application/CacheService.java
@@ -33,7 +33,7 @@ public class CacheService {
     private List<SimpleMenuFolderIconResponse> getMenuFolderIconInfo() {
         return Arrays.stream(MenuFolderIcon.values())
                 .map(menuFolderIcon -> {
-                    String menuFolderIconUrl = urlConvertor.getMenuFolderUrl(menuFolderIcon);
+                    String menuFolderIconUrl = urlConvertor.getMenuFolderImgUrl(menuFolderIcon);
                     return SimpleMenuFolderIconResponse.of(menuFolderIcon, menuFolderIconUrl);
                 })
                 .toList();

--- a/src/main/java/com/ourmenu/backend/domain/cache/util/MenuPinConverter.java
+++ b/src/main/java/com/ourmenu/backend/domain/cache/util/MenuPinConverter.java
@@ -1,0 +1,23 @@
+package com.ourmenu.backend.domain.cache.util;
+
+import com.ourmenu.backend.domain.cache.domain.MenuPin;
+import java.util.List;
+
+public class MenuPinConverter {
+
+    public static MenuPin of(List<MenuPin> menuPins) {
+        if (menuPins.size() == 1) {
+            return menuPins.get(0);
+        }
+        if (menuPins.size() == 2) {
+            return MenuPin.TWO;
+        }
+        if (menuPins.size() == 3) {
+            return MenuPin.THREE;
+        }
+        if (menuPins.size() == 4) {
+            return MenuPin.FOUR;
+        }
+        return MenuPin.FIVE;
+    }
+}

--- a/src/main/java/com/ourmenu/backend/domain/cache/util/MenuPinConverter.java
+++ b/src/main/java/com/ourmenu/backend/domain/cache/util/MenuPinConverter.java
@@ -5,6 +5,10 @@ import java.util.List;
 
 public class MenuPinConverter {
 
+    private MenuPinConverter() {
+
+    }
+
     public static MenuPin of(List<MenuPin> menuPins) {
         if (menuPins.size() == 1) {
             return menuPins.get(0);

--- a/src/main/java/com/ourmenu/backend/domain/cache/util/UrlConverter.java
+++ b/src/main/java/com/ourmenu/backend/domain/cache/util/UrlConverter.java
@@ -3,6 +3,7 @@ package com.ourmenu.backend.domain.cache.util;
 import com.ourmenu.backend.domain.cache.domain.HomeImg;
 import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
 import com.ourmenu.backend.domain.cache.domain.MenuPin;
+import com.ourmenu.backend.domain.home.domain.Answer;
 import com.ourmenu.backend.domain.tag.domain.Tag;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -45,6 +46,14 @@ public class UrlConverter {
 
     public String getWhiteTagImgUrl(Tag tag) {
         return url + "/tags/" + tag.getImgUrl() + "_white.svg";
+    }
+
+    public String getAnswerImgUrl(Answer answer) {
+        return url + "/answers/" + answer.toString() + ".svg";
+    }
+
+    public String getHomeRecommendTagImgUrl(Tag tag) {
+        return url + "/home_tags/" + tag.getTagEnum() + ".svg";
     }
 
     private boolean isETCMenuPin(MenuPin pin) {

--- a/src/main/java/com/ourmenu/backend/domain/cache/util/UrlConverter.java
+++ b/src/main/java/com/ourmenu/backend/domain/cache/util/UrlConverter.java
@@ -24,7 +24,7 @@ public class UrlConverter {
         return url + "/menu-pins/" + pin.getImgUrl() + "_add.svg";
     }
 
-    public String getMenuPinMapAddDiable(MenuPin pin) {
+    public String getMenuPinMapAddDisable(MenuPin pin) {
         if (isETCMenuPin(pin)) {
             return null;
         }

--- a/src/main/java/com/ourmenu/backend/domain/cache/util/UrlConverter.java
+++ b/src/main/java/com/ourmenu/backend/domain/cache/util/UrlConverter.java
@@ -32,7 +32,7 @@ public class UrlConverter {
         return url + "/menu-pins/" + pin.getImgUrl() + "_add_disable.svg";
     }
 
-    public String getMenuFolderUrl(MenuFolderIcon icon) {
+    public String getMenuFolderImgUrl(MenuFolderIcon icon) {
         return url + "/menu-folder-icons/" + icon.getImgUrl() + ".svg";
     }
 

--- a/src/main/java/com/ourmenu/backend/domain/home/application/HomeService.java
+++ b/src/main/java/com/ourmenu/backend/domain/home/application/HomeService.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.home.application;
 
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
 import com.ourmenu.backend.domain.home.dao.HomeQuestionAnswerRepository;
 import com.ourmenu.backend.domain.home.domain.Answer;
 import com.ourmenu.backend.domain.home.domain.HomeQuestionAnswer;
@@ -29,6 +30,7 @@ public class HomeService {
     private final RecommendMenuCacheService recommendMenuCacheService;
     private final MenuService menuService;
     private final MealTimeService mealTimeService;
+    private final UrlConverter urlConverter;
 
     /**
      * 홈 질문 응답 값을 저장 및 추천 메뉴를 캐싱한다. 질문에 관련 없는 응답이면 에러를 반환한다.
@@ -68,12 +70,12 @@ public class HomeService {
                     .userId(userId)
                     .build();
             HomeQuestionAnswer saveHomeQuestionAnswer = homeQuestionAnswerRepository.save(homeQuestionAnswer);
-            return SaveAndGetQuestionRequest.from(saveHomeQuestionAnswer);
+            return SaveAndGetQuestionRequest.from(saveHomeQuestionAnswer, urlConverter);
         }
 
         HomeQuestionAnswer homeQuestionAnswer = optionalHomeQuestionAnswer.get();
         homeQuestionAnswer.update(randomQuestion);
-        return SaveAndGetQuestionRequest.from(homeQuestionAnswer);
+        return SaveAndGetQuestionRequest.from(homeQuestionAnswer, urlConverter);
     }
 
     /**
@@ -91,7 +93,7 @@ public class HomeService {
         List<GetRecommendMenuResponse> randomRecommendMenus = getRandomRecommendMenu();
 
         return GetHomeRecommendResponse.of(answer, questionRecommendMenus, tagRandomRecommendDto.getTag(),
-                tagRandomRecommendDto.getGetRecommendMenuResponses(), randomRecommendMenus);
+                tagRandomRecommendDto.getGetRecommendMenuResponses(), randomRecommendMenus, urlConverter);
     }
 
     /**

--- a/src/main/java/com/ourmenu/backend/domain/home/domain/Answer.java
+++ b/src/main/java/com/ourmenu/backend/domain/home/domain/Answer.java
@@ -22,6 +22,7 @@ import com.ourmenu.backend.domain.cache.domain.HomeImg;
 import com.ourmenu.backend.domain.tag.domain.Tag;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 import lombok.Getter;
 
 @Getter
@@ -38,6 +39,7 @@ public enum Answer {
     SUMMER("여름", Tag.COOL, SUMMER1, SUMMER2, SUMMER3),
     WINTER("겨울", Tag.HOT, WINTER1, WINTER2);
 
+    private static final Random RANDOM = new Random();
     private String answer;
     private Tag tag;
     private List<HomeImg> homeImgs;
@@ -47,4 +49,9 @@ public enum Answer {
         this.tag = tag;
         this.homeImgs = Arrays.asList(homeImgs);
     }
+
+    public HomeImg getRandomHomeImg() {
+        return homeImgs.get(RANDOM.nextInt(homeImgs.size()));
+    }
+
 }

--- a/src/main/java/com/ourmenu/backend/domain/home/domain/Question.java
+++ b/src/main/java/com/ourmenu/backend/domain/home/domain/Question.java
@@ -5,6 +5,7 @@ import static com.ourmenu.backend.domain.home.domain.Answer.LIKE;
 import static com.ourmenu.backend.domain.home.domain.Answer.MOUNTAIN;
 import static com.ourmenu.backend.domain.home.domain.Answer.RAINY;
 import static com.ourmenu.backend.domain.home.domain.Answer.SEA;
+import static com.ourmenu.backend.domain.home.domain.Answer.SPICY;
 import static com.ourmenu.backend.domain.home.domain.Answer.SUMMER;
 import static com.ourmenu.backend.domain.home.domain.Answer.SUNNY;
 import static com.ourmenu.backend.domain.home.domain.Answer.SWEET;
@@ -19,7 +20,7 @@ public enum Question {
 
     FEEL("오늘 기분은 어떠신가요?", LIKE, DISLIKE),
     WEATHER("오늘 날씨는 어떤가요?", SUNNY, RAINY),
-    STRESS("스트레스 받을 때는 어떤 음식을 드시나요?", SWEET, RAINY),
+    STRESS("스트레스 받을 때는 어떤 음식을 드시나요?", SWEET, SPICY),
     TRIP("어디로 떠나고 싶은가요?", SEA, MOUNTAIN),
     SEASON("어느 계절을 더 좋아하세요?", SUMMER, WINTER);
 

--- a/src/main/java/com/ourmenu/backend/domain/home/dto/GetHomeRecommendResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/home/dto/GetHomeRecommendResponse.java
@@ -1,5 +1,7 @@
 package com.ourmenu.backend.domain.home.dto;
 
+import com.ourmenu.backend.domain.cache.domain.HomeImg;
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
 import com.ourmenu.backend.domain.home.domain.Answer;
 import com.ourmenu.backend.domain.tag.domain.Tag;
 import java.util.List;
@@ -13,22 +15,30 @@ import lombok.Getter;
 @Builder(access = AccessLevel.PRIVATE)
 public class GetHomeRecommendResponse {
 
-    private Answer answer;
+    private String answerImgUrl;
     private List<GetRecommendMenuResponse> answerRecommendMenus;
-    private Tag tag;
+    private String tagRecommendImgUrl;
     private List<GetRecommendMenuResponse> tagRecommendMenus;
+    private String otherRecommendImgUrl;
     private List<GetRecommendMenuResponse> otherRecommendMenus;
 
     public static GetHomeRecommendResponse of(Answer answer,
                                               List<GetRecommendMenuResponse> answerRecommendMenus,
                                               Tag tag,
                                               List<GetRecommendMenuResponse> tagRecommendMenus,
-                                              List<GetRecommendMenuResponse> otherRecommendMenus) {
+                                              List<GetRecommendMenuResponse> otherRecommendMenus,
+                                              UrlConverter urlConverter) {
+        HomeImg homeImg = answer.getRandomHomeImg();
+        String HomeImgUrl = urlConverter.getHomeImgUrl(homeImg);
+        String tagRecommendImgUrl = urlConverter.getHomeRecommendTagImgUrl(tag);
+        String otherRecommendImgUrl = tagRecommendImgUrl;
+
         return GetHomeRecommendResponse.builder()
-                .answer(answer)
+                .answerImgUrl(HomeImgUrl)
                 .answerRecommendMenus(answerRecommendMenus)
-                .tag(tag)
+                .tagRecommendImgUrl(tagRecommendImgUrl)
                 .tagRecommendMenus(tagRecommendMenus)
+                .otherRecommendImgUrl(otherRecommendImgUrl)
                 .otherRecommendMenus(otherRecommendMenus)
                 .build();
     }

--- a/src/main/java/com/ourmenu/backend/domain/home/dto/SaveAndGetQuestionRequest.java
+++ b/src/main/java/com/ourmenu/backend/domain/home/dto/SaveAndGetQuestionRequest.java
@@ -1,7 +1,10 @@
 package com.ourmenu.backend.domain.home.dto;
 
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
+import com.ourmenu.backend.domain.home.domain.Answer;
 import com.ourmenu.backend.domain.home.domain.HomeQuestionAnswer;
 import com.ourmenu.backend.domain.home.domain.Question;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,10 +16,35 @@ import lombok.Getter;
 public class SaveAndGetQuestionRequest {
 
     private Question question;
+    private List<AnswerDto> answers;
 
-    public static SaveAndGetQuestionRequest from(HomeQuestionAnswer homeQuestionAnswer) {
-        return SaveAndGetQuestionRequest.builder()
-                .question(homeQuestionAnswer.getQuestion())
+    public static SaveAndGetQuestionRequest from(HomeQuestionAnswer homeQuestionAnswer, UrlConverter urlConverter) {
+        Question question = homeQuestionAnswer.getQuestion();
+
+        Answer answer1 = question.getAnswer1();
+        AnswerDto answerDto1 = AnswerDto.builder()
+                .answer(answer1)
+                .answerImgUrl(urlConverter.getAnswerImgUrl(answer1))
                 .build();
+
+        Answer answer2 = question.getAnswer2();
+        AnswerDto answerDto2 = AnswerDto.builder()
+                .answer(answer2)
+                .answerImgUrl(urlConverter.getAnswerImgUrl(answer2))
+                .build();
+
+        return SaveAndGetQuestionRequest.builder()
+                .question(question)
+                .answers(List.of(answerDto1, answerDto2))
+                .build();
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    @Builder(access = AccessLevel.PRIVATE)
+    private static class AnswerDto {
+        private Answer answer;
+        private String answerImgUrl;
+
     }
 }

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MenuFolderService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MenuFolderService.java
@@ -95,7 +95,7 @@ public class MenuFolderService {
         menuFolder.update(menuFolderDto);
         List<MenuMenuFolder> menuMenuFolders = menuMenuFolderService.findAllByMenuFolderId(menuFolderId);
         return UpdateMenuFolderResponse.of(menuFolder, menuMenuFolders,
-                defaultImgConvertor.getDefaultMenuFolderImgUrl());
+                defaultImgConvertor.getDefaultMenuFolderImgUrl(), urlConverter);
     }
 
     /**
@@ -126,7 +126,7 @@ public class MenuFolderService {
         findMenuFolder.updateIndex(index);
         List<MenuMenuFolder> menuMenuFolders = menuMenuFolderService.findAllByMenuFolderId(menuFolderId);
         return UpdateMenuFolderResponse.of(findMenuFolder, menuMenuFolders,
-                defaultImgConvertor.getDefaultMenuFolderImgUrl());
+                defaultImgConvertor.getDefaultMenuFolderImgUrl(), urlConverter);
     }
 
 

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MenuFolderService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MenuFolderService.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.application;
 
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
 import com.ourmenu.backend.domain.menu.dao.MenuFolderRepository;
 import com.ourmenu.backend.domain.menu.dao.MenuRepository;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
@@ -28,6 +29,7 @@ public class MenuFolderService {
     private final MenuMenuFolderService menuMenuFolderService;
     private final DefaultImgConverter defaultImgConvertor;
     private final MenuRepository menuRepository;
+    private final UrlConverter urlConverter;
 
     /**
      * 메뉴 폴더 저장
@@ -43,7 +45,7 @@ public class MenuFolderService {
 
         MenuFolder menuFolder = saveMenuFolder(menuFolderDto, menuFolderImgUrl);
         return SaveMenuFolderResponse.of(menuFolder, menuFolderDto.getMenuIds(),
-                defaultImgConvertor.getDefaultMenuFolderImgUrl());
+                defaultImgConvertor.getDefaultMenuFolderImgUrl(), urlConverter);
     }
 
     /**
@@ -142,7 +144,7 @@ public class MenuFolderService {
                     List<MenuMenuFolder> menuMenuFolders = menuMenuFolderService.findAllByMenuFolderId(
                             menuFolder.getId());
                     return MenuFolderResponse.of(menuFolder, menuMenuFolders,
-                            defaultImgConvertor.getDefaultMenuFolderImgUrl());
+                            defaultImgConvertor.getDefaultMenuFolderImgUrl(), urlConverter);
                 }).toList();
         int menuCount = menuRepository.countByUserId(userId);
         return GetMenuFolderResponse.of(menuCount, menuFolderResponses);

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MenuService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MenuService.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.application;
 
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
 import com.ourmenu.backend.domain.home.dto.GetRecommendMenuResponse;
 import com.ourmenu.backend.domain.menu.dao.MenuRepository;
 import com.ourmenu.backend.domain.menu.domain.Menu;
@@ -40,6 +41,7 @@ public class MenuService {
     private final MenuImgService menuImgService;
     private final MenuFolderService menuFolderService;
     private final DefaultImgConverter defaultImgConverter;
+    private final UrlConverter urlConverter;
 
     /**
      * 메뉴 저장(메뉴 사진, 메뉴판, 태그 의존 엔티티 생성

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MenuService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MenuService.java
@@ -55,7 +55,7 @@ public class MenuService {
         Store store = storeService.saveStoreAndMap(menuDto.getStoreTitle(), menuDto.getStoreAddress(),
                 menuDto.getMapX(),
                 menuDto.getMapY());
-
+        
         Menu menu = Menu.builder()
                 .title(menuDto.getMenuTitle())
                 .price(menuDto.getMenuPrice())

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MenuService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MenuService.java
@@ -218,7 +218,7 @@ public class MenuService {
         List<String> imgUrls = menuImgService.findImgUrls(menuId);
         List<Tag> tags = menuTagService.findTagNames(menuId);
         List<MenuFolder> menuFolders = menuFolderService.findAllByMenuId(menuId);
-        return GetMenuResponse.of(menu, imgUrls, tags, menuFolders);
+        return GetMenuResponse.of(menu, imgUrls, tags, menuFolders, urlConverter);
     }
 
 

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MenuService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MenuService.java
@@ -78,7 +78,8 @@ public class MenuService {
 
         //s3 업로드및 이미지 연관관계 생성
         List<MenuImg> menuImgs = menuImgService.saveMenuImgs(saveMenu.getId(), menuDto.getMenuImgs());
-        return SaveMenuResponse.of(saveMenu, store, store.getMap(), menuImgs, saveMenuMenuFolders, saveTag);
+        return SaveMenuResponse.of(saveMenu, store, store.getMap(), menuImgs, saveMenuMenuFolders, saveTag,
+                urlConverter);
     }
 
     /**
@@ -127,7 +128,7 @@ public class MenuService {
         MenuFolder menuFolder = menuFolderService.findOne(userId, menuFolderId);
 
         return GetMenuFolderMenuResponse.of(menuFolder, defaultImgConverter.getDefaultMenuFolderImgUrl(),
-                menuResponses);
+                menuResponses, urlConverter);
     }
 
     /**

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuFolderMenuResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuFolderMenuResponse.java
@@ -26,7 +26,7 @@ public class GetMenuFolderMenuResponse {
             menuFolderImgUrl = defaultMenuFolderImgUrl;
         }
 
-        String menuFolderIconImgUrl = urlConverter.getMenuFolderUrl(menuFolder.getIcon());
+        String menuFolderIconImgUrl = urlConverter.getMenuFolderImgUrl(menuFolder.getIcon());
 
         return GetMenuFolderMenuResponse.builder()
                 .menuFolderId(menuFolder.getId())

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuFolderMenuResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuFolderMenuResponse.java
@@ -1,6 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
-import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
 import java.util.List;
 import lombok.AccessLevel;
@@ -16,21 +16,23 @@ public class GetMenuFolderMenuResponse {
     private Long menuFolderId;
     private String menuFolderTitle;
     private String menuFolderImgUrl;
-    private MenuFolderIcon menuFolderIcon;
+    private String menuFolderIconImgUrl;
     private List<MenuFolderMenuResponse> menus;
 
     public static GetMenuFolderMenuResponse of(MenuFolder menuFolder, String defaultMenuFolderImgUrl,
-                                               List<MenuFolderMenuResponse> menus) {
+                                               List<MenuFolderMenuResponse> menus, UrlConverter urlConverter) {
         String menuFolderImgUrl = menuFolder.getImgUrl();
         if (menuFolderImgUrl == null) {
             menuFolderImgUrl = defaultMenuFolderImgUrl;
         }
 
+        String menuFolderIconImgUrl = urlConverter.getMenuFolderUrl(menuFolder.getIcon());
+
         return GetMenuFolderMenuResponse.builder()
                 .menuFolderId(menuFolder.getId())
                 .menuFolderTitle(menuFolder.getTitle())
                 .menuFolderImgUrl(menuFolderImgUrl)
-                .menuFolderIcon(menuFolder.getIcon())
+                .menuFolderIconImgUrl(menuFolderIconImgUrl)
                 .menus(menus)
                 .build();
     }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuResponse.java
@@ -41,7 +41,7 @@ public class GetMenuResponse {
 
         List<SimpleMenuFolder> simpleMenuFolders = menuFolders.stream()
                 .map(menuFolder -> {
-                    String menuFolderIconImgUrl = urlConverter.getMenuFolderUrl(menuFolder.getIcon());
+                    String menuFolderIconImgUrl = urlConverter.getMenuFolderImgUrl(menuFolder.getIcon());
                     return SimpleMenuFolder.builder()
                             .menuFolderId(menuFolder.getId())
                             .menuFolderTitle(menuFolder.getTitle())

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/GetMenuResponse.java
@@ -1,7 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
-import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
-import com.ourmenu.backend.domain.cache.domain.MenuPin;
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
 import com.ourmenu.backend.domain.menu.domain.Menu;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
 import com.ourmenu.backend.domain.tag.domain.Tag;
@@ -19,10 +18,10 @@ public class GetMenuResponse {
     private Long menuId;
     private String menuTitle;
     private int menuPrice;
-    private MenuPin menuPin;
+    private String menuPinImgUrl;
     private String storeTitle;
     private String storeAddress;
-    private List<Tag> tags;
+    private List<String> tagImgUrls;
     private List<String> menuImgUrls;
 
     private List<SimpleMenuFolder> menuFolders;
@@ -33,26 +32,35 @@ public class GetMenuResponse {
     private static class SimpleMenuFolder {
         private Long menuFolderId;
         private String menuFolderTitle;
-        private MenuFolderIcon menuFolderIcon;
+        private String menuFolderIconImgUrl;
     }
 
     public static GetMenuResponse of(Menu menu, List<String> imgUrls, List<Tag> tags,
-                                     List<MenuFolder> menuFolders) {
+                                     List<MenuFolder> menuFolders, UrlConverter urlConverter) {
+        String menuPinImgUrl = urlConverter.getMenuPinMapUrl(menu.getPin());
+
         List<SimpleMenuFolder> simpleMenuFolders = menuFolders.stream()
-                .map(menuFolder -> SimpleMenuFolder.builder()
-                        .menuFolderId(menuFolder.getId())
-                        .menuFolderTitle(menuFolder.getTitle())
-                        .menuFolderIcon(menuFolder.getIcon())
-                        .build())
+                .map(menuFolder -> {
+                    String menuFolderIconImgUrl = urlConverter.getMenuFolderUrl(menuFolder.getIcon());
+                    return SimpleMenuFolder.builder()
+                            .menuFolderId(menuFolder.getId())
+                            .menuFolderTitle(menuFolder.getTitle())
+                            .menuFolderIconImgUrl(menuFolderIconImgUrl)
+                            .build();
+                })
                 .toList();
+        List<String> tagImgUrls = tags.stream()
+                .map(urlConverter::getOrangeTagImgUrl)
+                .toList();
+
         return GetMenuResponse.builder().
                 menuId(menu.getId())
                 .menuTitle(menu.getTitle())
                 .menuPrice(menu.getPrice())
-                .menuPin(menu.getPin())
+                .menuPinImgUrl(menuPinImgUrl)
                 .storeAddress(menu.getStore().getAddress())
                 .storeTitle(menu.getStore().getTitle())
-                .tags(tags)
+                .tagImgUrls(tagImgUrls)
                 .menuImgUrls(imgUrls)
                 .menuFolders(simpleMenuFolders)
                 .build();

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderInfoOnMapDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderInfoOnMapDto.java
@@ -1,6 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
-import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,13 +10,15 @@ import lombok.Getter;
 public class MenuFolderInfoOnMapDto {
 
     private String menuFolderTitle;
-    private MenuFolderIcon menuFolderIcon;
+    private String menuFolderIconImgUrl;
     private int menuFolderCount;
 
-    public static MenuFolderInfoOnMapDto of(MenuFolder menuFolder, int count) {
+    public static MenuFolderInfoOnMapDto of(MenuFolder menuFolder, int count, UrlConverter urlConverter) {
+        String menuFolderIconImgUrl = urlConverter.getMenuFolderUrl(menuFolder.getIcon());
+
         return MenuFolderInfoOnMapDto.builder()
                 .menuFolderTitle(menuFolder.getTitle())
-                .menuFolderIcon(menuFolder.getIcon())
+                .menuFolderIconImgUrl(menuFolderIconImgUrl)
                 .menuFolderCount(count)
                 .build();
     }
@@ -24,7 +26,7 @@ public class MenuFolderInfoOnMapDto {
     public static MenuFolderInfoOnMapDto empty() {
         return MenuFolderInfoOnMapDto.builder()
                 .menuFolderTitle("")
-                .menuFolderIcon(null)
+                .menuFolderIconImgUrl(null)
                 .menuFolderCount(0)
                 .build();
     }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderInfoOnMapDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderInfoOnMapDto.java
@@ -14,7 +14,7 @@ public class MenuFolderInfoOnMapDto {
     private int menuFolderCount;
 
     public static MenuFolderInfoOnMapDto of(MenuFolder menuFolder, int count, UrlConverter urlConverter) {
-        String menuFolderIconImgUrl = urlConverter.getMenuFolderUrl(menuFolder.getIcon());
+        String menuFolderIconImgUrl = urlConverter.getMenuFolderImgUrl(menuFolder.getIcon());
 
         return MenuFolderInfoOnMapDto.builder()
                 .menuFolderTitle(menuFolder.getTitle())

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderResponse.java
@@ -1,6 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
-import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
 import com.ourmenu.backend.domain.menu.domain.MenuMenuFolder;
 import java.util.List;
@@ -17,16 +17,18 @@ public class MenuFolderResponse {
     private Long menuFolderId;
     private String menuFolderTitle;
     private String menuFolderImgUrl;
-    private MenuFolderIcon menuFolderIcon;
+    private String menuFolderIconImgUrl;
     private List<Long> menuIds;
     private int index;
 
     public static MenuFolderResponse of(MenuFolder menuFolder, List<MenuMenuFolder> menuFolders,
-                                        String defaultMenuFolderImgUrl) {
+                                        String defaultMenuFolderImgUrl, UrlConverter urlConverter) {
         String menuFolderImgUrl = menuFolder.getImgUrl();
         if (menuFolderImgUrl == null) {
             menuFolderImgUrl = defaultMenuFolderImgUrl;
         }
+
+        String menuFolderIconImgUrl = urlConverter.getMenuFolderUrl(menuFolder.getIcon());
 
         List<Long> menuIds = menuFolders.stream()
                 .map(menuMenuFolder -> menuMenuFolder.getMenu().getId())
@@ -35,7 +37,7 @@ public class MenuFolderResponse {
                 .menuFolderId(menuFolder.getId())
                 .menuFolderTitle(menuFolder.getTitle())
                 .menuFolderImgUrl(menuFolderImgUrl)
-                .menuFolderIcon(menuFolder.getIcon())
+                .menuFolderIconImgUrl(menuFolderIconImgUrl)
                 .menuIds(menuIds)
                 .index(menuFolder.getIndex())
                 .build();

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderResponse.java
@@ -28,7 +28,7 @@ public class MenuFolderResponse {
             menuFolderImgUrl = defaultMenuFolderImgUrl;
         }
 
-        String menuFolderIconImgUrl = urlConverter.getMenuFolderUrl(menuFolder.getIcon());
+        String menuFolderIconImgUrl = urlConverter.getMenuFolderImgUrl(menuFolder.getIcon());
 
         List<Long> menuIds = menuFolders.stream()
                 .map(menuMenuFolder -> menuMenuFolder.getMenu().getId())

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuInfoOnMapDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuInfoOnMapDto.java
@@ -1,10 +1,9 @@
 package com.ourmenu.backend.domain.menu.dto;
 
-import com.ourmenu.backend.domain.cache.domain.MenuPin;
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
 import com.ourmenu.backend.domain.menu.domain.Menu;
 import com.ourmenu.backend.domain.menu.domain.MenuImg;
 import com.ourmenu.backend.domain.tag.domain.MenuTag;
-import com.ourmenu.backend.domain.tag.domain.Tag;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Builder;
@@ -17,8 +16,8 @@ public class MenuInfoOnMapDto {
     private Long menuId;
     private String menuTitle;
     private Integer menuPrice;
-    private MenuPin menuPin;
-    private List<Tag> menuTags;
+    private String menuPinImgUrl;
+    private List<String> menuTagImgUrls;
     private List<String> menuImgUrls;
     private MenuFolderInfoOnMapDto menuFolderInfo;
     private Long mapId;
@@ -26,15 +25,19 @@ public class MenuInfoOnMapDto {
     private Double mapY;
 
     public static MenuInfoOnMapDto of(Menu menu, List<MenuTag> menuTags, List<MenuImg> menuImgs,
-                                      MenuFolderInfoOnMapDto menuFolderInfo) {
+                                      MenuFolderInfoOnMapDto menuFolderInfo, UrlConverter urlConverter) {
+        String menuPinImgUrl = urlConverter.getMenuPinMapUrl(menu.getPin());
+        List<String> menuTagImgUrls = menuTags.stream()
+                .map(MenuTag::getTag)
+                .map(urlConverter::getOrangeTagImgUrl)
+                .toList();
+
         return MenuInfoOnMapDto.builder()
                 .menuId(menu.getId())
                 .menuTitle(menu.getTitle())
                 .menuPrice(menu.getPrice())
-                .menuPin(menu.getPin())
-                .menuTags(menuTags.stream().map(
-                        MenuTag::getTag
-                ).collect(Collectors.toList()))
+                .menuPinImgUrl(menuPinImgUrl)
+                .menuTagImgUrls(menuTagImgUrls)
                 .menuImgUrls(menuImgs.stream().map(
                         menuImg -> menuImg.getImgUrl()
                 ).collect(Collectors.toList()))

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuOnMapDto.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuOnMapDto.java
@@ -1,10 +1,11 @@
 package com.ourmenu.backend.domain.menu.dto;
 
 import com.ourmenu.backend.domain.cache.domain.MenuPin;
+import com.ourmenu.backend.domain.cache.util.MenuPinConverter;
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
 import com.ourmenu.backend.domain.menu.domain.Menu;
 import com.ourmenu.backend.domain.store.domain.Map;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,16 +14,24 @@ import lombok.Getter;
 public class MenuOnMapDto {
 
     private Long mapId;
-    private List<MenuPin> menuPins;
+    private String menuPinImgUrl;
+    private String menuPinDisableImgUrl;
     private Double mapX;
     private Double mapY;
 
-    public static MenuOnMapDto from(Map map, List<Menu> menus) {
+    public static MenuOnMapDto from(Map map, List<Menu> menus, UrlConverter urlConverter) {
+
+        List<MenuPin> menuPins = menus.stream()
+                .map(Menu::getPin)
+                .toList();
+        MenuPin menuPin = MenuPinConverter.of(menuPins);
+        String menuPinImgUrl = urlConverter.getMenuPinMapUrl(menuPin);
+        String menuPinDisableImgUrl = urlConverter.getMenuPinMapAddDisable(menuPin);
+
         return MenuOnMapDto.builder()
                 .mapId(map.getId())
-                .menuPins(menus.stream()
-                        .map(Menu::getPin)
-                        .collect(Collectors.toList()))
+                .menuPinImgUrl(menuPinImgUrl)
+                .menuPinDisableImgUrl(menuPinDisableImgUrl)
                 .mapX(map.getLocation().getX())
                 .mapY(map.getLocation().getY())
                 .build();

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuFolderResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuFolderResponse.java
@@ -1,6 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
-import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
 import java.util.List;
 import lombok.AccessLevel;
@@ -16,13 +16,14 @@ public class SaveMenuFolderResponse {
     private Long menuFolderId;
     private String menuFolderTitle;
     private String menuFolderUrl;
-    private MenuFolderIcon menuFolderIcon;
+    private String menuFolderIconImgUrl;
     private List<Long> menuIds;
     private int index;
 
     public static SaveMenuFolderResponse of(MenuFolder menuFolder, List<Long> menuIds,
-                                            String defaultMenuFolderImgUrl) {
+                                            String defaultMenuFolderImgUrl, UrlConverter urlConverter) {
         String menuFolderImgUrl = menuFolder.getImgUrl();
+        String menuFolderIconImgUrl = urlConverter.getMenuFolderUrl(menuFolder.getIcon());
         if (menuFolderImgUrl == null) {
             menuFolderImgUrl = defaultMenuFolderImgUrl;
         }
@@ -31,7 +32,7 @@ public class SaveMenuFolderResponse {
                 .menuFolderId(menuFolder.getId())
                 .menuFolderTitle(menuFolder.getTitle())
                 .menuFolderUrl(menuFolderImgUrl)
-                .menuFolderIcon(menuFolder.getIcon())
+                .menuFolderIconImgUrl(menuFolderIconImgUrl)
                 .menuIds(menuIds)
                 .index(menuFolder.getIndex())
                 .build();

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuFolderResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuFolderResponse.java
@@ -23,7 +23,7 @@ public class SaveMenuFolderResponse {
     public static SaveMenuFolderResponse of(MenuFolder menuFolder, List<Long> menuIds,
                                             String defaultMenuFolderImgUrl, UrlConverter urlConverter) {
         String menuFolderImgUrl = menuFolder.getImgUrl();
-        String menuFolderIconImgUrl = urlConverter.getMenuFolderUrl(menuFolder.getIcon());
+        String menuFolderIconImgUrl = urlConverter.getMenuFolderImgUrl(menuFolder.getIcon());
         if (menuFolderImgUrl == null) {
             menuFolderImgUrl = defaultMenuFolderImgUrl;
         }

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/SaveMenuResponse.java
@@ -1,6 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
-import com.ourmenu.backend.domain.cache.domain.MenuPin;
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
 import com.ourmenu.backend.domain.menu.domain.Menu;
 import com.ourmenu.backend.domain.menu.domain.MenuImg;
 import com.ourmenu.backend.domain.menu.domain.MenuMenuFolder;
@@ -23,10 +23,10 @@ public class SaveMenuResponse {
     private int menuPrice;
     private String menuMemoTitle;
     private String menuMemoContent;
-    private MenuPin menuPin;
+    private String menuPinImgUrl;
     private List<Long> menuFolderIds;
     private boolean isCrawled;
-    private List<Tag> tags;
+    private List<String> tagImgUrls;
     private String storeTitle;
     private String storeAddress;
     private Double storeMapX;
@@ -34,19 +34,27 @@ public class SaveMenuResponse {
     private List<String> menuImgUrls;
 
     public static SaveMenuResponse of(Menu menu, Store store, Map map, List<MenuImg> menuImgs,
-                                      List<MenuMenuFolder> menuMenuFolders, List<Tag> tags) {
-        List<String> menuImgUrls = menuImgs.stream().map(MenuImg::getImgUrl).toList();
-        List<Long> menuFolderIds = menuMenuFolders.stream().map(MenuMenuFolder::getFolderId).toList();
+                                      List<MenuMenuFolder> menuMenuFolders, List<Tag> tags, UrlConverter urlConverter) {
+        String menuPinImgUrl = urlConverter.getMenuPinAddUrl(menu.getPin());
+        List<Long> menuFolderIds = menuMenuFolders.stream()
+                .map(MenuMenuFolder::getFolderId)
+                .toList();
+        List<String> tagImgUrls = tags.stream()
+                .map(urlConverter::getOrangeTagImgUrl)
+                .toList();
+        List<String> menuImgUrls = menuImgs.stream()
+                .map(MenuImg::getImgUrl)
+                .toList();
         return SaveMenuResponse.builder()
                 .menuId(menu.getId())
                 .menuTitle(menu.getTitle())
                 .menuPrice(menu.getPrice())
                 .menuMemoTitle(menu.getMemoTitle())
                 .menuMemoContent(menu.getMemoContent())
-                .menuPin(menu.getPin())
+                .menuPinImgUrl(menuPinImgUrl)
                 .menuFolderIds(menuFolderIds)
                 .isCrawled(menu.getIsCrawled())
-                .tags(tags)
+                .tagImgUrls(tagImgUrls)
                 .storeTitle(store.getTitle())
                 .storeAddress(store.getAddress())
                 .storeMapX(map.getLocation().getX())

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/UpdateMenuFolderResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/UpdateMenuFolderResponse.java
@@ -1,6 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
-import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
 import com.ourmenu.backend.domain.menu.domain.MenuMenuFolder;
 import java.util.List;
@@ -17,16 +17,18 @@ public class UpdateMenuFolderResponse {
     private Long menuFolderId;
     private String menuFolderTitle;
     private String menuFolderUrl;
-    private MenuFolderIcon menuFolderIcon;
+    private String menuFolderIconImgUrl;
     private List<Long> menuIds;
     private int index;
 
     public static UpdateMenuFolderResponse of(MenuFolder menuFolder, List<MenuMenuFolder> menuMenuFolders,
-                                              String defaultMenuFolderImgUrl) {
+                                              String defaultMenuFolderImgUrl, UrlConverter urlConverter) {
         String menuFolderImgUrl = menuFolder.getImgUrl();
         if (menuFolderImgUrl == null) {
             menuFolderImgUrl = defaultMenuFolderImgUrl;
         }
+
+        String menuFolderIconImgUrl = urlConverter.getMenuFolderUrl(menuFolder.getIcon());
 
         List<Long> menuId = menuMenuFolders.stream()
                 .map(menuMenuFolder -> menuMenuFolder.getMenu().getId())
@@ -35,7 +37,7 @@ public class UpdateMenuFolderResponse {
                 .menuFolderId(menuFolder.getId())
                 .menuFolderTitle(menuFolder.getTitle())
                 .menuFolderUrl(menuFolderImgUrl)
-                .menuFolderIcon(menuFolder.getIcon())
+                .menuFolderIconImgUrl(menuFolderIconImgUrl)
                 .menuIds(menuId)
                 .index(menuFolder.getIndex())
                 .build();

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/UpdateMenuFolderResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/UpdateMenuFolderResponse.java
@@ -16,7 +16,7 @@ public class UpdateMenuFolderResponse {
 
     private Long menuFolderId;
     private String menuFolderTitle;
-    private String menuFolderUrl;
+    private String menuFolderImgUrl;
     private String menuFolderIconImgUrl;
     private List<Long> menuIds;
     private int index;
@@ -28,7 +28,7 @@ public class UpdateMenuFolderResponse {
             menuFolderImgUrl = defaultMenuFolderImgUrl;
         }
 
-        String menuFolderIconImgUrl = urlConverter.getMenuFolderUrl(menuFolder.getIcon());
+        String menuFolderIconImgUrl = urlConverter.getMenuFolderImgUrl(menuFolder.getIcon());
 
         List<Long> menuId = menuMenuFolders.stream()
                 .map(menuMenuFolder -> menuMenuFolder.getMenu().getId())
@@ -36,7 +36,7 @@ public class UpdateMenuFolderResponse {
         return UpdateMenuFolderResponse.builder()
                 .menuFolderId(menuFolder.getId())
                 .menuFolderTitle(menuFolder.getTitle())
-                .menuFolderUrl(menuFolderImgUrl)
+                .menuFolderImgUrl(menuFolderImgUrl)
                 .menuFolderIconImgUrl(menuFolderIconImgUrl)
                 .menuIds(menuId)
                 .index(menuFolder.getIndex())

--- a/src/test/java/com/ourmenu/backend/domain/home/api/HomeApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/home/api/HomeApiTest.java
@@ -1,5 +1,7 @@
 package com.ourmenu.backend.domain.home.api;
 
+import com.ourmenu.backend.domain.cache.domain.HomeImg;
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
 import com.ourmenu.backend.domain.home.config.HomeTestConfig;
 import com.ourmenu.backend.domain.home.data.HomeTestData;
 import com.ourmenu.backend.domain.home.domain.Answer;
@@ -27,6 +29,9 @@ public class HomeApiTest {
 
     @Autowired
     HomeController homeController;
+
+    @Autowired
+    UrlConverter urlConverter;
 
     @Autowired
     HomeTestData homeTestData;
@@ -95,8 +100,13 @@ public class HomeApiTest {
 
         //then
         Assertions.assertThat(response.isSuccess()).isEqualTo(true);
-        Assertions.assertThat(response.getResponse().getAnswer()).isEqualTo(Answer.LIKE);
         Assertions.assertThat(response.getResponse().getAnswerRecommendMenus().size()).isEqualTo(2);
+
+        Assertions.assertThat(response.getResponse().getAnswerImgUrl()).satisfiesAnyOf(
+                answerImgUrl -> Assertions.assertThat(answerImgUrl)
+                        .isEqualTo(urlConverter.getHomeImgUrl(HomeImg.LIKE1)),
+                answerImgUrl -> Assertions.assertThat(answerImgUrl).isEqualTo(urlConverter.getHomeImgUrl(HomeImg.LIKE2))
+        );
     }
 
 }

--- a/src/test/java/com/ourmenu/backend/domain/menu/api/MenuApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/menu/api/MenuApiTest.java
@@ -1,6 +1,7 @@
 package com.ourmenu.backend.domain.menu.api;
 
 import com.ourmenu.backend.domain.cache.domain.MenuPin;
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
 import com.ourmenu.backend.domain.menu.config.MenuTestConfig;
 import com.ourmenu.backend.domain.menu.data.MenuTestData;
 import com.ourmenu.backend.domain.menu.domain.Menu;
@@ -35,6 +36,9 @@ public class MenuApiTest {
     MenuController menuController;
 
     @Autowired
+    UrlConverter urlConverter;
+
+    @Autowired
     GlobalUserTestData userTestData;
 
     @Autowired
@@ -62,9 +66,11 @@ public class MenuApiTest {
 
         //then
         Assertions.assertThat(response.isSuccess()).isTrue();
-        Assertions.assertThat(response.getResponse().getMenuFolderIcon()).isEqualTo(testMenuFolder.getIcon());
         Assertions.assertThat(response.getResponse().getMenuFolderTitle()).isEqualTo(testMenuFolder.getTitle());
         Assertions.assertThat(response.getResponse().getMenus().size()).isEqualTo(3);
+
+        Assertions.assertThat(response.getResponse().getMenuFolderIconImgUrl())
+                .isEqualTo(urlConverter.getMenuFolderImgUrl(testMenuFolder.getIcon()));
     }
 
     @Test
@@ -80,8 +86,10 @@ public class MenuApiTest {
 
         //then
         Assertions.assertThat(response.isSuccess()).isTrue();
-        Assertions.assertThat(response.getResponse().getMenuPin()).isEqualTo(MenuPin.BBQ);
         Assertions.assertThat(response.getResponse().getMenuMemoTitle()).isEqualTo(menuMemoTitle);
+
+        Assertions.assertThat(response.getResponse().getMenuPinImgUrl())
+                .isEqualTo(urlConverter.getMenuPinAddUrl(MenuPin.BBQ));
     }
 
     @Test

--- a/src/test/java/com/ourmenu/backend/domain/menu/api/MenuFolderApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/menu/api/MenuFolderApiTest.java
@@ -1,6 +1,7 @@
 package com.ourmenu.backend.domain.menu.api;
 
 import com.ourmenu.backend.domain.cache.domain.MenuFolderIcon;
+import com.ourmenu.backend.domain.cache.util.UrlConverter;
 import com.ourmenu.backend.domain.menu.config.MenuTestConfig;
 import com.ourmenu.backend.domain.menu.data.MenuTestData;
 import com.ourmenu.backend.domain.menu.domain.MenuFolder;
@@ -31,6 +32,9 @@ public class MenuFolderApiTest {
 
     @Autowired
     MenuFolderController menuFolderController;
+
+    @Autowired
+    UrlConverter urlConverter;
 
     @Autowired
     GlobalUserTestData userTestData;
@@ -151,9 +155,9 @@ public class MenuFolderApiTest {
         Assertions.assertThat(updateMenuFolderResponseApiResponse.isSuccess()).isEqualTo(true);
         Assertions.assertThat(updateMenuFolderResponseApiResponse.getResponse().getMenuFolderTitle())
                 .isEqualTo(modifiedMenuFolderName);
-        Assertions.assertThat(updateMenuFolderResponseApiResponse.getResponse().getMenuFolderIcon())
-                .isEqualTo(testMenuFolder.getIcon());
 
+        Assertions.assertThat(updateMenuFolderResponseApiResponse.getResponse().getMenuFolderIconImgUrl())
+                .isEqualTo(urlConverter.getMenuFolderImgUrl(testMenuFolder.getIcon()));
     }
 
     @Test


### PR DESCRIPTION
### ✏️ 작업 개요
- #97 

### ⛳ 작업 분류
- [x] ENUM -> URL 변경
- [x] 지도 메뉴핀 변환 (MenuPinConverter)
- [x] 누락된 홈 로직 추가
- [x] 일부 버그 수정 

### 🔨 작업 상세 내용
1. 응답값을 ENUM에서 URL으로 모든 API에 대해 변경하였습니다.
2. 이제 클라이언트의 요청에 대해서는 ENUM으로 소통하되, 응답은 URL로 소통합니다
3. 일부 API에서 응답에 대해 클라이언트가 알아야하는 경우, enum을 추가로 제공합니다 (home API)
4. 홈 로직중 누락된 부분에 대해서 완성하였습니다.

### 💡 생각해볼 문제
- 값을 어디서 변경해야하는지 고민해보았는데, Response에서 UrlConverter를 매개변수로 추가하는 방식으로 해결하였습니다 (이게 최선일까요..)
-  **변경을 어디서 하는게 올바른지 의견이 궁금합니다.** ⭐⭐⭐
- 홈 추천 메뉴 조회중 랜덤 추천 메뉴의 경우, 추천 문구 UI가 확인 안되서 일단 **동일한 문구로 초기화**하도록 처리하였습니다.
