### PR TITLE
[FIX] 메뉴 단순 조회 관련 API 수정

### DIFF
--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/GetSimpleMenuResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/GetSimpleMenuResponse.java
@@ -1,6 +1,7 @@
 package com.ourmenu.backend.domain.menu.dto;
 
 import com.ourmenu.backend.domain.menu.domain.Menu;
+import com.ourmenu.backend.domain.store.util.AddressParser;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -21,11 +22,13 @@ public class GetSimpleMenuResponse {
     private LocalDateTime createdAt;
 
     public static GetSimpleMenuResponse of(Menu menu, String menuImgUrl) {
+        String storeAddress = AddressParser.parseAddressToCityDistrict(menu.getStore().getAddress());
+
         return GetSimpleMenuResponse.builder()
                 .menuId(menu.getId())
                 .menuTitle(menu.getTitle())
                 .storeTitle(menu.getStore().getTitle())
-                .storeAddress(menu.getStore().getAddress())
+                .storeAddress(storeAddress)
                 .menuPrice(menu.getPrice())
                 .menuImgUrl(menuImgUrl)
                 .createdAt(menu.getCreatedAt())

--- a/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderMenuResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dto/MenuFolderMenuResponse.java
@@ -1,5 +1,6 @@
 package com.ourmenu.backend.domain.menu.dto;
 
+import com.ourmenu.backend.domain.store.util.AddressParser;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -20,11 +21,13 @@ public class MenuFolderMenuResponse {
     private LocalDateTime createdAt;
 
     public static MenuFolderMenuResponse of(MenuSimpleDto menuSimpleDto, String menuImgUrl) {
+        String storeAddress = AddressParser.parseAddressToCityDistrict(menuSimpleDto.getStoreAddress());
+
         return MenuFolderMenuResponse.builder()
                 .menuId(menuSimpleDto.getMenuId())
                 .menuTitle(menuSimpleDto.getMenuTitle())
                 .storeTitle(menuSimpleDto.getStoreTitle())
-                .storeAddress(menuSimpleDto.getStoreAddress())
+                .storeAddress(storeAddress)
                 .menuPrice(menuSimpleDto.getMenuPrice())
                 .menuImgUrl(menuImgUrl)
                 .createdAt(menuSimpleDto.getCreatedAt())

--- a/src/main/java/com/ourmenu/backend/domain/store/util/AddressParser.java
+++ b/src/main/java/com/ourmenu/backend/domain/store/util/AddressParser.java
@@ -1,0 +1,25 @@
+package com.ourmenu.backend.domain.store.util;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class AddressParser {
+
+    private AddressParser() {
+    }
+
+    private static List<String> parseAddress(String address) {
+        return Arrays.stream(address.split(" ")).toList();
+    }
+
+    public static String parseAddressToCityDistrict(String address) {
+        List<String> addresses = parseAddress(address);
+        if (addresses.size() >= 2) {
+            return addresses.get(0) + " " + addresses.get(1);
+        }
+        if (addresses.size() == 1) {
+            return addresses.get(0);
+        }
+        return "";
+    }
+}

--- a/src/test/java/com/ourmenu/backend/domain/store/unit/AddressTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/store/unit/AddressTest.java
@@ -1,0 +1,37 @@
+package com.ourmenu.backend.domain.store.unit;
+
+import com.ourmenu.backend.domain.store.util.AddressParser;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("주소 파싱 단위 테스트")
+public class AddressTest {
+
+
+    @Test
+    void 상세주소를_시_구_조합으로_변환_할_수_있다() {
+        //given
+        String cityDistrict = "서울 광진구";
+        String address = "서울 광진구 능동로16길 57 (우)05021";
+
+        //when
+        String simpleAddress = AddressParser.parseAddressToCityDistrict(address);
+
+        //then
+        Assertions.assertThat(simpleAddress).isEqualTo(cityDistrict);
+    }
+
+    @Test
+    void 옳지못한_주소에_대해서_예외를_발생시키지_않는다() {
+        //given
+        String address = "서울";
+
+        //when
+        String simpleAddress = AddressParser.parseAddressToCityDistrict(address);
+
+        //then
+        Assertions.assertThat(simpleAddress).isEqualTo(address);
+    }
+
+}


### PR DESCRIPTION
### ✏️ 작업 개요
- #110 

### ⛳ 작업 분류
- [x] AddressParser 추가
- [x] GET/api/menus 응답 필드 변경
- [x] GET/api/menu-folders/{menuFolderId}/menus 응답 필드 변경

### 🔨 작업 상세 내용
1. 일부 엔드포인트에 대해 전체 주소가 아닌 시+구 주소만을 반환하도록 API를 수정하였습니다 ex) "서울시 광진구"

### 💡 생각해볼 문제
- 생각해볼 내용을 적습니다
