### PR TITLE
[FIX] 카카오 검증 API 수정

### DIFF
--- a/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
@@ -238,7 +238,8 @@ public class UserService {
         Optional<User> optionalUser = userRepository.findByEmailAndSignInType(email, SignInType.KAKAO);
 
         if (optionalUser.isPresent() && optionalUser.get().getSignInType().equals(SignInType.KAKAO)) {
-            return KakaoExistenceResponse.from(true);
+            TokenDto token = jwtTokenProvider.createAllToken(email, SignInType.KAKAO);
+            return KakaoExistenceResponse.from(true, token);
         }
 
         return KakaoExistenceResponse.from(false);

--- a/src/main/java/com/ourmenu/backend/domain/user/dto/response/KakaoExistenceResponse.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/dto/response/KakaoExistenceResponse.java
@@ -3,15 +3,31 @@ package com.ourmenu.backend.domain.user.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.Instant;
+
 @Getter
 @Builder
 public class KakaoExistenceResponse {
 
     private boolean isExistUser;
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+    private Instant refreshTokenExpiredAt;
 
     public static KakaoExistenceResponse from(boolean isExistUser){
         return KakaoExistenceResponse.builder()
                 .isExistUser(isExistUser)
+                .build();
+    }
+
+    public static KakaoExistenceResponse from(boolean isExistUser, TokenDto tokenDto){
+        return KakaoExistenceResponse.builder()
+                .isExistUser(isExistUser)
+                .grantType(tokenDto.getGrantType())
+                .accessToken(tokenDto.getAccessToken())
+                .refreshToken(tokenDto.getRefreshToken())
+                .refreshTokenExpiredAt(tokenDto.getRefreshTokenExpiredAt())
                 .build();
     }
 }

--- a/src/main/java/com/ourmenu/backend/global/util/JwtTokenProvider.java
+++ b/src/main/java/com/ourmenu/backend/global/util/JwtTokenProvider.java
@@ -45,7 +45,7 @@ public class JwtTokenProvider {
     private Key key;
     private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
 
-    private static final long ACCESS_TIME = 60 * 60 * 1000L;   // 1시간
+    private static final long ACCESS_TIME = 30 * 24 * 60 * 60 * 1000L;   // 1시간 -> 30일로 임시 변경
     private static final long REFRESH_TIME = 30 * 24 * 60 * 60 * 1000L;    // 30일
     public static final String ACCESS_TOKEN = "Authorization";
     public static final String REFRESH_TOKEN = "Refresh-Token";

--- a/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
+++ b/src/test/java/com/ourmenu/backend/domain/user/api/UserApiTest.java
@@ -100,6 +100,7 @@ public class UserApiTest {
 
         //then
         Assertions.assertThat(response.isSuccess()).isEqualTo(true);
+        Assertions.assertThat(response.getResponse().isExistUser()).isEqualTo(true);
     }
     
     @Test


### PR DESCRIPTION
### ✏️ 작업 개요
- closed #121 

### ⛳ 작업 분류
- [ ] AccessToken 유효기간 임시 변경
- [ ] 카카오 검증 API 수정 및 테스트 코드 수정

### 🔨 작업 상세 내용
1. AccessToken의 유효기간을 임시 변경하였습니다. (이후 다시 복구 예정)
2. 기존의 카카오 검증 API의 경우, 클라이언트로부터 이메일을 받고, 해당 이메일을 가진 SignInType이 KAKAO인 유저가 DB에 저장되어 있는 지에 대한 여부만 반환하였습니다.

- 존재하는 경우 ->  로그인 API 호출
- 존재하지 않는 경우 -> 회원가입 

즉, 카카오 로그인의 경우 반드시 두 번의 API가 호출되어야 했습니다. 계정이 존재하지 않는 경우는 필연적이라고 생각하며, 계정이 존재하는 경우에는 바로 JWT를 발급하여 로그인 할 수 있도록 변경했습니다. (클라이언트와 회의 및 API 명세서 수정 완료)

### 💡 생각해볼 문제
- X
