### PR TITLE
[REFACTOR] 지도 API 쿼리 최적화

### DIFF
--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
@@ -60,8 +60,6 @@ public class MapService {
      * @return
      */
     public List<MenuOnMapDto> findMenusOnMap(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(NotFoundUserException::new);
         List<Menu> menus = menuRepository.findMenusByUserId(userId);
 
         java.util.Map<Map, List<Menu>> menuMaps = menus.stream()
@@ -99,9 +97,6 @@ public class MapService {
      * @return
      */
     public List<MapSearchDto> findSearchResultOnMap(String title, double mapX, double mapY, Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(NotFoundUserException::new);
-
         GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
         Point userLocation = geometryFactory.createPoint(new Coordinate(mapX, mapY));
 
@@ -122,9 +117,6 @@ public class MapService {
      * @return
      */
     public List<MapSearchHistoryDto> findSearchHistoryOnMap(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(NotFoundUserException::new);
-
         Pageable pageable = PageRequest.of(
                 0,
                 10,
@@ -148,9 +140,6 @@ public class MapService {
      */
     @Transactional
     public MenuInfoOnMapDto findMenuByMenuIdOnMap(Long menuId, Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(NotFoundUserException::new);
-
         Menu menu = menuRepository.findByIdAndUserId(menuId, userId)
                 .orElseThrow(NotFoundMenuException::new);
 

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
@@ -20,9 +20,6 @@ import com.ourmenu.backend.domain.store.dao.MapRepository;
 import com.ourmenu.backend.domain.store.domain.Map;
 import com.ourmenu.backend.domain.tag.dao.MenuTagRepository;
 import com.ourmenu.backend.domain.tag.domain.MenuTag;
-import com.ourmenu.backend.domain.user.dao.UserRepository;
-import com.ourmenu.backend.domain.user.domain.User;
-import com.ourmenu.backend.domain.user.exception.NotFoundUserException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,7 +29,6 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -45,7 +41,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class MapService {
 
     private final MenuRepository menuRepository;
-    private final UserRepository userRepository;
     private final MapRepository mapRepository;
     private final MenuTagRepository menuTagRepository;
     private final MenuImgRepository menuImgRepository;

--- a/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/application/MapService.java
@@ -102,7 +102,7 @@ public class MapService {
 
         PageRequest pageRequest = PageRequest.of(0, 10);
 
-        Page<Menu> menusByUserIdOrderByDistance =
+        List<Menu> menusByUserIdOrderByDistance =
                 menuRepository.findByUserIdTitleContainingOrderByDistance(userId, title, userLocation, pageRequest);
 
         return menusByUserIdOrderByDistance.stream()
@@ -118,12 +118,10 @@ public class MapService {
      */
     public List<MapSearchHistoryDto> findSearchHistoryOnMap(Long userId) {
         Pageable pageable = PageRequest.of(
-                0,
-                10,
-                Sort.by(Sort.Direction.DESC, "modifiedAt")
+                0, 10, Sort.by(Sort.Direction.DESC, "modifiedAt")
         );
 
-        Page<OwnedMenuSearch> searchHistoryPage = ownedMenuSearchRepository
+        List<OwnedMenuSearch> searchHistoryPage = ownedMenuSearchRepository
                 .findByUserId(userId, pageable);
 
         return searchHistoryPage.stream()

--- a/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
@@ -269,15 +269,15 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
                                            @Param("tag") String tag,
                                            Pageable pageable);
 
-    @Query("""
-        SELECT m 
-        FROM Menu m
-            JOIN FETCH m.store s
-            JOIN FETCH s.map map
-        WHERE m.userId = :userId
-            AND LOWER(m.title) LIKE CONCAT('%', LOWER(:title), '%')  
-            ORDER BY ST_Distance_Sphere(map.location, :userLocation) ASC
-    """)
+    @Query(value = """
+        SELECT m.*
+        FROM menu m
+            JOIN store s ON m.store_id = s.id
+            JOIN map ON s.map_id = map.id
+        WHERE m.user_id = :userId
+            AND LOWER(m.title) LIKE CONCAT('%', LOWER(:title), '%')
+        ORDER BY ST_Distance_Sphere(map.location, :userLocation) ASC
+        """, nativeQuery = true)
     List<Menu> findByUserIdTitleContainingOrderByDistance(
             @Param("userId") Long userId,
             @Param("title") String title,

--- a/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/menu/dao/MenuRepository.java
@@ -19,6 +19,13 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     boolean existsByStore(Store store);
 
+    @Query("""
+        SELECT m
+        FROM Menu m
+            JOIN FETCH m.store s
+            JOIN FETCH s.map map
+        WHERE m.userId = :userId
+    """)
     List<Menu> findMenusByUserId(Long userId);
 
     List<Menu> findMenusByStoreIdAndUserId(Long storeId, Long userId);
@@ -26,8 +33,6 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
     boolean existsByUserIdAndId(Long userId, Long id);
 
     Optional<Menu> findByIdAndUserId(Long menuId, Long userId);
-
-    List<Menu> findByUserIdAndStoreId(Long userId, Long storeId);
 
     int countByUserId(Long userId);
 
@@ -264,23 +269,20 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
                                            @Param("tag") String tag,
                                            Pageable pageable);
 
-    @Query(
-            value = "SELECT m.* FROM menu m " +
-                    "JOIN store s ON m.store_id = s.id " +
-                    "JOIN map ON s.map_id = map.id " +
-                    "WHERE m.user_id = :userId " +
-                    "AND LOWER(m.title) LIKE CONCAT('%', LOWER(:title), '%') " +
-                    "ORDER BY ST_Distance_Sphere(map.location, :userLocation) ASC",
-            countQuery = "SELECT COUNT(*) FROM menu m " +
-                    "JOIN store s ON m.store_id = s.id " +
-                    "JOIN map ON s.map_id = map.id " +
-                    "WHERE m.user_id = :userId " +
-                    "AND LOWER(m.title) LIKE CONCAT('%', LOWER(:title), '%')",
-            nativeQuery = true
-    )
-    Page<Menu> findByUserIdTitleContainingOrderByDistance(@Param("userId") Long userId,
-                                                          @Param("title") String title,
-                                                          @Param("userLocation") Point userLocation,
-                                                          Pageable pageable);
+    @Query("""
+        SELECT m 
+        FROM Menu m
+            JOIN FETCH m.store s
+            JOIN FETCH s.map map
+        WHERE m.userId = :userId
+            AND LOWER(m.title) LIKE CONCAT('%', LOWER(:title), '%')  
+            ORDER BY ST_Distance_Sphere(map.location, :userLocation) ASC
+    """)
+    List<Menu> findByUserIdTitleContainingOrderByDistance(
+            @Param("userId") Long userId,
+            @Param("title") String title,
+            @Param("userLocation") Point userLocation,
+            Pageable pageable
+    );
 }
 

--- a/src/main/java/com/ourmenu/backend/domain/search/dao/OwnedMenuSearchRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/search/dao/OwnedMenuSearchRepository.java
@@ -1,11 +1,12 @@
 package com.ourmenu.backend.domain.search.dao;
 
 import com.ourmenu.backend.domain.search.domain.OwnedMenuSearch;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface OwnedMenuSearchRepository extends JpaRepository<OwnedMenuSearch, Long> {
 
-    Page<OwnedMenuSearch> findByUserId(Long userId, Pageable pageable);
+    List<OwnedMenuSearch> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/ourmenu/backend/domain/store/dao/MapRepository.java
+++ b/src/main/java/com/ourmenu/backend/domain/store/dao/MapRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.locationtech.jts.geom.Point;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,5 +13,11 @@ public interface MapRepository extends JpaRepository<Map, Long> {
 
     Optional<Map> findByLocation(Point location);
 
+    @Query("""
+        SELECT m
+        FROM Map m
+            JOIN FETCH m.stores s
+        WHERE m.id = :mapId
+    """)
     Optional<Map> findMapById(Long mapId);
 }

--- a/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
+++ b/src/main/java/com/ourmenu/backend/domain/user/application/UserService.java
@@ -23,7 +23,6 @@ import com.ourmenu.backend.domain.user.exception.NotFoundUserException;
 import com.ourmenu.backend.domain.user.exception.NotMatchPasswordException;
 import com.ourmenu.backend.domain.user.exception.NotMatchTokenException;
 import com.ourmenu.backend.domain.user.exception.TokenExpiredExcpetion;
-import com.ourmenu.backend.domain.user.exception.UnsupportedSignInTypeException;
 import com.ourmenu.backend.global.util.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 


### PR DESCRIPTION
### ✏️ 작업 개요
- closed #127 

### ⛳ 작업 분류
- [x] 유저 검증 중복 제거
- [x] N+1 문제 해결
- [x] Page -> List 타입 변경

### 🔨 작업 상세 내용
1. 토큰 검증 시 유저 DB 조회를 진행하고 있는데, 이를 API 호출 시점에서 한 번 더 DB 조회 및 검증을 진행하고 있어 제거하였습니다.
2. 지도 API의 대부분이 N+1 문제가 발생하고 있었는데, 이를 해결하였습니다. 다만 지도 상세 조회 및 지도 메뉴 상세 조회 API의 경우 메뉴태그, 메뉴판, 메뉴 이미지의 경우 연관관계상 추가적인 쿼리가 발생합니다. 
```
        List<MenuTag> menuTags = menuTagRepository.findMenuTagsByMenuId(menu.getId());
        List<MenuImg> menuImgs = menuImgRepository.findAllByMenuId(menu.getId());
        List<MenuFolder> menuFolders = menuFolderRepository.findMenuFoldersByMenuId(menu.getId());
```
4. Page 타입의 경우 추가적인 Count 쿼리가 발생하는데, 현재 Response 상에서 Page가 제공하는 총 개수, 페이지 등과 같은 메타 정보를 사용하지 않아 List 타입으로 변경하였습니다.

### 💡 생각해볼 문제
- X
